### PR TITLE
Update Hero styles for Financial sector dashboards

### DIFF
--- a/dashboards/currency-in-circulation/index.tsx
+++ b/dashboards/currency-in-circulation/index.tsx
@@ -154,21 +154,13 @@ const CurrencyInCirculationDashboard: FunctionComponent<CurrencyInCirculationDas
 
   return (
     <>
-      <Hero background="currency-in-circulation-banner">
-        <div className="space-y-4 xl:w-2/3">
-          <span className="text-sm font-bold uppercase tracking-widest text-primary">
-            {t("nav.megamenu.categories.financial_sector")}
-          </span>
-          <h3>{t("currencyincirculation.header")}</h3>
-          <p className="text-dim">{t("currencyincirculation.description")}</p>
-
-          <p className="text-sm text-dim">
-            {t("common.last_updated", {
-              date: toDate(last_updated, "dd MMM yyyy, HH:mm", i18n.language),
-            })}
-          </p>
-        </div>
-      </Hero>
+      <Hero
+        className="bg-teal-50/25"
+        category={[t("nav.megamenu.categories.financial_sector")]}
+        header={[t("currencyincirculation.header")]}
+        description={[t("currencyincirculation.description")]}
+        last_updated={last_updated}
+      />
 
       <Container className="min-h-screen">
         {/* A snapshot of currency currently in circulation */}

--- a/dashboards/interest-rates/index.tsx
+++ b/dashboards/interest-rates/index.tsx
@@ -157,21 +157,13 @@ const InterestRatesDashboard: FunctionComponent<InterestRatesDashboardProps> = (
 
   return (
     <>
-      <Hero background="interest-rates-banner">
-        <div className="space-y-4 xl:w-2/3">
-          <span className="text-sm font-bold uppercase tracking-widest text-primary">
-            {t("nav.megamenu.categories.financial_sector")}
-          </span>
-          <h3>{t("interest_rates.header")}</h3>
-          <p className="text-dim">{t("interest_rates.description")}</p>
-
-          <p className="text-sm text-dim">
-            {t("common.last_updated", {
-              date: toDate(last_updated, "dd MMM yyyy, HH:mm", i18n.language),
-            })}
-          </p>
-        </div>
-      </Hero>
+      <Hero
+        className="bg-teal-50/25"
+        category={[t("nav.megamenu.categories.financial_sector")]}
+        header={[t("interest_rates.header")]}
+        description={[t("interest_rates.description")]}
+        last_updated={last_updated}
+      />
 
       <Container className="min-h-screen">
         {/* How is interest rates trending? */}

--- a/dashboards/international-reserves/index.tsx
+++ b/dashboards/international-reserves/index.tsx
@@ -78,21 +78,13 @@ const InternationalReservesDashboard: FunctionComponent<InternationalReservesDas
 
   return (
     <>
-      <Hero background="money-supply-banner">
-        <div className="space-y-4 xl:w-2/3">
-          <span className="text-sm font-bold uppercase tracking-widest text-primary">
-            {t("nav.megamenu.categories.financial_sector")}
-          </span>
-          <h3>{t("international_reserves.header")}</h3>
-          <p className="text-black lg:text-dim">{t("international_reserves.description")}</p>
-
-          <p className="text-sm text-dim">
-            {t("common.last_updated", {
-              date: toDate(last_updated, "dd MMM yyyy, HH:mm", i18n.language),
-            })}
-          </p>
-        </div>
-      </Hero>
+      <Hero
+        className="bg-teal-50/25"
+        category={[t("nav.megamenu.categories.financial_sector")]}
+        header={[t("international_reserves.header")]}
+        description={[t("international_reserves.description")]}
+        last_updated={last_updated}
+      />
 
       <Container className="min-h-screen">
         {/* Key measures of BNM’s international reserves */}

--- a/dashboards/money-supply/index.tsx
+++ b/dashboards/money-supply/index.tsx
@@ -226,21 +226,13 @@ const MoneySupplyDashboard: FunctionComponent<MoneySupplyDashboardProps> = ({
 
   return (
     <>
-      <Hero background="money-supply-banner">
-        <div className="space-y-4 xl:w-2/3">
-          <span className="text-sm font-bold uppercase tracking-widest text-primary">
-            {t("nav.megamenu.categories.financial_sector")}
-          </span>
-          <h3>{t("moneysupply.header")}</h3>
-          <p className="text-dim">{t("moneysupply.description")}</p>
-
-          <p className="text-sm text-dim">
-            {t("common.last_updated", {
-              date: toDate(last_updated, "dd MMM yyyy, HH:mm", i18n.language),
-            })}
-          </p>
-        </div>
-      </Hero>
+      <Hero
+        className="bg-teal-50/25"
+        category={[t("nav.megamenu.categories.financial_sector")]}
+        header={[t("moneysupply.header")]}
+        description={[t("moneysupply.description")]}
+        last_updated={last_updated}
+      />
 
       <Container className="min-h-screen">
         {/* What are the various ways to measure the supply of money in Malaysia? */}

--- a/dashboards/reserve-money/index.tsx
+++ b/dashboards/reserve-money/index.tsx
@@ -155,21 +155,13 @@ const ReserveMoneyDashboard: FunctionComponent<ReserveMoneyDashboardProps> = ({
 
   return (
     <>
-      <Hero background="reserve-money-banner">
-        <div className="space-y-4 xl:w-2/3">
-          <span className="text-sm font-bold uppercase tracking-widest text-primary">
-            {t("nav.megamenu.categories.financial_sector")}
-          </span>
-          <h3>{t("reservemoney.header")}</h3>
-          <p className="text-dim">{t("reservemoney.description")}</p>
-
-          <p className="text-sm text-dim">
-            {t("common.last_updated", {
-              date: toDate(last_updated, "dd MMM yyyy, HH:mm", i18n.language),
-            })}
-          </p>
-        </div>
-      </Hero>
+      <Hero
+        className="bg-teal-50/25"
+        category={[t("nav.megamenu.categories.financial_sector")]}
+        header={[t("reservemoney.header")]}
+        description={[t("reservemoney.description")]}
+        last_updated={last_updated}
+      />
 
       <Container className="min-h-screen">
         {/* How is reserve money trending? */}

--- a/pages/currency-in-circulation/index.tsx
+++ b/pages/currency-in-circulation/index.tsx
@@ -38,7 +38,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   const { data } = await get("/dashboard", { dashboard: "currency" });
 
   return {
-    notFound: true,
+    notFound: false,
     props: {
       ...i18n,
       last_updated: new Date().valueOf(),

--- a/pages/interest-rates/index.tsx
+++ b/pages/interest-rates/index.tsx
@@ -105,7 +105,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   data.timeseries_opr.data["recession"] = data.timeseries.data.recession;
 
   return {
-    notFound: true,
+    notFound: false,
     props: {
       ...i18n,
       last_updated: new Date().valueOf(),

--- a/pages/international-reserves/index.tsx
+++ b/pages/international-reserves/index.tsx
@@ -36,7 +36,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   const { data } = await get("/dashboard", { dashboard: "international_reserves" });
 
   return {
-    notFound: true,
+    notFound: false,
     props: {
       ...i18n,
       last_updated: new Date().valueOf(),

--- a/pages/money-supply/index.tsx
+++ b/pages/money-supply/index.tsx
@@ -36,7 +36,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   const { data } = await get("/dashboard", { dashboard: "money_measures" });
 
   return {
-    notFound: true,
+    notFound: false,
     props: {
       ...i18n,
       last_updated: new Date().valueOf(),

--- a/pages/reserve-money/index.tsx
+++ b/pages/reserve-money/index.tsx
@@ -36,7 +36,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   const { data } = await get("/dashboard", { dashboard: "reserves" });
 
   return {
-    notFound: true,
+    notFound: false,
     props: {
       ...i18n,
       last_updated: new Date().valueOf(),


### PR DESCRIPTION
- Update Hero components styling using the predefined styles in the Hero component by passing the title, description and last updated texts into the Hero component as props.
- The background image has been removed and "bg-teal-50/25" is used as a temporary background colour. 
- The dashboards are enabled by setting false to notFound under getStaticProps(). 
- 5 dashboards have been updated - Currency in Circulation, Money Supply, Reserve Money, International Reserves & Interest Rates


