### PR TITLE
feat/immigration

### DIFF
--- a/apps/app/components/Chart/Timeseries/index.tsx
+++ b/apps/app/components/Chart/Timeseries/index.tsx
@@ -30,7 +30,6 @@ import {
 } from "chart.js";
 import { CrosshairPlugin } from "chartjs-plugin-crosshair";
 import AnnotationPlugin from "chartjs-plugin-annotation";
-
 import { Chart } from "react-chartjs-2";
 import { clx, numFormat } from "@lib/helpers";
 import "chartjs-adapter-luxon";
@@ -38,6 +37,7 @@ import { ChartCrosshairOption } from "@lib/types";
 import { ChartJSOrUndefined } from "react-chartjs-2/dist/types";
 import { useTheme } from "next-themes";
 import { AKSARA_COLOR } from "@lib/constants";
+import Spinner from "@components/Spinner";
 
 export type Periods =
   | false
@@ -58,6 +58,7 @@ export interface TimeseriesProps extends ChartHeaderProps {
   data?: ChartData<keyof ChartTypeRegistry, any[], string | number>;
   mode?: "grouped" | "stacked";
   subheader?: ReactElement;
+  isLoading?: boolean;
   interval?: Periods;
   tooltipFormat?: string;
   round?: Periods;
@@ -101,6 +102,7 @@ const Timeseries: FunctionComponent<TimeseriesProps> = ({
   title,
   description,
   controls,
+  isLoading = false,
   interval = "auto",
   tooltipFormat,
   prefixY,
@@ -392,11 +394,19 @@ const Timeseries: FunctionComponent<TimeseriesProps> = ({
   return (
     <div className="space-y-2">
       <ChartHeader title={title} menu={menu} controls={controls} state={state} />
-      {stats && <Stats data={stats} />}
-      {subheader && <div>{subheader}</div>}
-      <div className={className}>
-        <Chart ref={_ref} data={data} options={options()} type={type} />
-      </div>
+      {isLoading ? (
+        <div className={clx("flex items-center justify-center", className)}>
+          <Spinner loading={isLoading} />
+        </div>
+      ) : (
+        <>
+          {stats && <Stats data={stats} />}
+          {subheader && <div>{subheader}</div>}
+          <div className={className}>
+            <Chart ref={_ref} data={data} options={options()} type={type} />
+          </div>
+        </>
+      )}
       {description && <p className="text-dim pt-4 text-sm">{description}</p>}
     </div>
   );
@@ -448,14 +458,9 @@ export type StatProps = {
 };
 
 export const Stats: FunctionComponent<StatsProps> = ({ data, className }) => {
-  const cols: Record<number, string> = {
-    1: "grid-cols-1",
-    2: "grid-cols-2",
-    3: "grid-cols-3",
-  };
   return (
-    <div className={clx("flex flex-row space-x-8", className)}>
-      {data.map(({ title, value, tooltip }: StatProps, index) => (
+    <div className={clx("flex flex-row space-x-6 lg:space-x-8", className)}>
+      {data.map(({ title, value, tooltip }: StatProps) => (
         <div key={`${title}_${value}`}>
           <p className="text-dim text-sm">{title}</p>
           {tooltip ? (

--- a/apps/app/components/Combobox/index.tsx
+++ b/apps/app/components/Combobox/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from "react";
+import { Fragment, ReactNode, useState } from "react";
 import ImageWithFallback from "@components/ImageWithFallback";
 import { OptionType } from "@components/types";
 import { Combobox, Transition } from "@headlessui/react";
@@ -16,6 +16,7 @@ type ComboBoxProps<L, V> = {
   placeholder?: string;
   enableFlag?: boolean;
   imageSource?: string;
+  fallback?: ReactNode;
   enableType?: boolean;
   loading?: boolean;
 };
@@ -28,6 +29,7 @@ const ComboBox = <L extends string | number = string, V = string>({
   placeholder,
   enableFlag = false,
   imageSource = "/static/images/parties/",
+  fallback,
   enableType = false,
   loading = false,
 }: ComboBoxProps<L, V>) => {
@@ -122,6 +124,7 @@ const ComboBox = <L extends string | number = string, V = string>({
                           <ImageWithFallback
                             className="border-outline dark:border-washed-dark rounded border"
                             src={`${imageSource}${option.value}.png`}
+                            fallback={fallback}
                             width={32}
                             height={18}
                             alt={option.value as string}

--- a/apps/app/components/Combobox/index.tsx
+++ b/apps/app/components/Combobox/index.tsx
@@ -15,6 +15,7 @@ type ComboBoxProps<L, V> = {
   onSearch?: (query: string) => void;
   placeholder?: string;
   enableFlag?: boolean;
+  imageSource?: string;
   enableType?: boolean;
   loading?: boolean;
 };
@@ -26,6 +27,7 @@ const ComboBox = <L extends string | number = string, V = string>({
   onSearch,
   placeholder,
   enableFlag = false,
+  imageSource = "/static/images/parties/",
   enableType = false,
   loading = false,
 }: ComboBoxProps<L, V>) => {
@@ -119,7 +121,7 @@ const ComboBox = <L extends string | number = string, V = string>({
                         <>
                           <ImageWithFallback
                             className="border-outline dark:border-washed-dark rounded border"
-                            src={`/static/images/parties/${option.value}.png`}
+                            src={`${imageSource}${option.value}.png`}
                             width={32}
                             height={18}
                             alt={option.value as string}

--- a/apps/app/components/ImageWithFallback/index.tsx
+++ b/apps/app/components/ImageWithFallback/index.tsx
@@ -12,7 +12,7 @@ const Fallback: FunctionComponent<FallbackProps> = ({ children }) => {
   );
 };
 interface ImageWithFallbackProps extends ImageProps {
-  fallback: ReactNode;
+  fallback?: ReactNode;
 }
 
 const ImageWithFallback = ({ fallback, alt, src, ...props }: ImageWithFallbackProps) => {

--- a/apps/app/components/ImageWithFallback/index.tsx
+++ b/apps/app/components/ImageWithFallback/index.tsx
@@ -23,7 +23,7 @@ const ImageWithFallback = ({ fallback, alt, src, ...props }: ImageWithFallbackPr
   }, [src]);
 
   return error ? (
-    <Fallback children={fallback} />
+    <Fallback>{fallback}</Fallback>
   ) : (
     <Image alt={alt} onError={setError} src={src} {...props} />
   );

--- a/apps/app/components/ImageWithFallback/index.tsx
+++ b/apps/app/components/ImageWithFallback/index.tsx
@@ -1,24 +1,31 @@
 import Image, { ImageProps } from "next/image";
-import { useEffect, useState } from "react";
+import { FunctionComponent, ReactNode, useEffect, useState } from "react";
 
-import fallbackImage from "public/static/images/parties/fallback.png";
-
+interface FallbackProps {
+  children?: ReactNode;
+}
+const Fallback: FunctionComponent<FallbackProps> = ({ children }) => {
+  return (
+    <div className="border-outline dark:border-outlineHover-dark h-5 w-[30px] rounded border bg-white">
+      {children ?? <div className="text-center font-black leading-4 text-black">?</div>}
+    </div>
+  );
+};
 interface ImageWithFallbackProps extends ImageProps {
-  fallback?: ImageProps["src"];
+  fallback: ReactNode;
 }
 
-const ImageWithFallback = ({
-  fallback = fallbackImage,
-  alt,
-  src,
-  ...props
-}: ImageWithFallbackProps) => {
+const ImageWithFallback = ({ fallback, alt, src, ...props }: ImageWithFallbackProps) => {
   const [error, setError] = useState<React.SyntheticEvent<HTMLImageElement, Event> | null>(null);
 
   useEffect(() => {
     setError(null);
   }, [src]);
 
-  return <Image alt={alt} onError={setError} src={error ? fallbackImage : src} {...props} />;
+  return error ? (
+    <Fallback children={fallback} />
+  ) : (
+    <Image alt={alt} onError={setError} src={src} {...props} />
+  );
 };
 export default ImageWithFallback;

--- a/apps/app/components/Section/index.tsx
+++ b/apps/app/components/Section/index.tsx
@@ -41,25 +41,28 @@ const Section: FunctionComponent<SectionProps> = forwardRef(
         <div className="flex flex-col gap-6 lg:gap-8">
           {title || date || description ? (
             <div className="space-y-2">
-              <div className="flex flex-col flex-wrap items-start gap-3 lg:flex-row lg:items-center lg:justify-between">
-                <div className="flex flex-col gap-2">
-                  {title && typeof title === "string" ? <h4>{title}</h4> : title}
+              <div className="flex flex-col flex-wrap items-start gap-2 lg:flex-row lg:items-center lg:justify-between">
+                {title && typeof title === "string" ? <h4>{title}</h4> : title}
+                {date && date !== null && (
+                  <span className="text-dim text-right text-sm">
+                    {t("common:common.data_of", { date: displayDate })}
+                  </span>
+                )}
+              </div>
+              {(description || menu) && (
+                <div className="text-dim flex flex-wrap gap-x-6 gap-y-3 md:flex-nowrap md:items-end md:justify-between">
                   {description && typeof description === "string" ? (
-                    <p className={["text-dim whitespace-pre-line text-base"].join(" ")}>
+                    <p
+                      className={[
+                        "whitespace-pre-line text-base",
+                        menu ? "md:max-w-[70%]" : "",
+                      ].join(" ")}
+                    >
                       {description}
                     </p>
                   ) : (
                     <div>{description}</div>
                   )}
-                </div>
-                {date && date !== null && (
-                  <span className="text-dim self-start text-right text-sm">
-                    {t("common:common.data_of", { date: displayDate })}
-                  </span>
-                )}
-              </div>
-              {menu && (
-                <div className="text-dim flex flex-wrap gap-x-6 gap-y-3 md:flex-nowrap md:items-end md:justify-between">
                   {menu && <div className="flex w-full justify-end gap-3 md:w-auto">{menu}</div>}
                 </div>
               )}

--- a/apps/app/components/Section/index.tsx
+++ b/apps/app/components/Section/index.tsx
@@ -41,20 +41,13 @@ const Section: FunctionComponent<SectionProps> = forwardRef(
         <div className="flex flex-col gap-6 lg:gap-8">
           {title || date || description ? (
             <div className="space-y-2">
-              <div className="flex flex-col flex-wrap items-start gap-2 lg:flex-row lg:items-center lg:justify-between">
-                {title && typeof title === "string" ? <h4>{title}</h4> : title}
-                {date && date !== null && (
-                  <span className="text-dim text-right text-sm">
-                    {t("common:common.data_of", { date: displayDate })}
-                  </span>
-                )}
-              </div>
-              {(description || menu) && (
-                <div className="text-dim flex flex-wrap gap-x-6 gap-y-3 md:flex-nowrap md:items-end md:justify-between">
+              <div className="flex flex-col flex-wrap items-start gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div className="flex flex-col gap-2">
+                  {title && typeof title === "string" ? <h4>{title}</h4> : title}
                   {description && typeof description === "string" ? (
                     <p
                       className={[
-                        "whitespace-pre-line text-base",
+                        "text-dim whitespace-pre-line text-base",
                         menu ? "md:max-w-[70%]" : "",
                       ].join(" ")}
                     >
@@ -63,6 +56,15 @@ const Section: FunctionComponent<SectionProps> = forwardRef(
                   ) : (
                     <div>{description}</div>
                   )}
+                </div>
+                {date && date !== null && (
+                  <span className="text-dim text-right text-sm">
+                    {t("common:common.data_of", { date: displayDate })}
+                  </span>
+                )}
+              </div>
+              {menu && (
+                <div className="text-dim flex flex-wrap gap-x-6 gap-y-3 md:flex-nowrap md:items-end md:justify-between">
                   {menu && <div className="flex w-full justify-end gap-3 md:w-auto">{menu}</div>}
                 </div>
               )}

--- a/apps/app/components/Section/index.tsx
+++ b/apps/app/components/Section/index.tsx
@@ -45,12 +45,7 @@ const Section: FunctionComponent<SectionProps> = forwardRef(
                 <div className="flex flex-col gap-2">
                   {title && typeof title === "string" ? <h4>{title}</h4> : title}
                   {description && typeof description === "string" ? (
-                    <p
-                      className={[
-                        "text-dim whitespace-pre-line text-base",
-                        menu ? "md:max-w-[70%]" : "",
-                      ].join(" ")}
-                    >
+                    <p className={["text-dim whitespace-pre-line text-base"].join(" ")}>
                       {description}
                     </p>
                   ) : (
@@ -58,7 +53,7 @@ const Section: FunctionComponent<SectionProps> = forwardRef(
                   )}
                 </div>
                 {date && date !== null && (
-                  <span className="text-dim text-right text-sm">
+                  <span className="text-dim self-start text-right text-sm">
                     {t("common:common.data_of", { date: displayDate })}
                   </span>
                 )}

--- a/apps/app/components/Tabs/index.tsx
+++ b/apps/app/components/Tabs/index.tsx
@@ -42,7 +42,7 @@ const List: FunctionComponent<ListProps> = ({ options, current, onChange, icons 
         <li
           key={option}
           className={clx(
-            "flex cursor-pointer flex-row self-center rounded-full px-[10px] py-1 text-sm outline-none transition-colors",
+            "flex cursor-pointer self-center whitespace-nowrap rounded-full px-[10px] py-1 text-sm outline-none transition-colors",
             current === index
               ? "bg-outline dark:bg-washed-dark font-medium text-black dark:text-white"
               : "text-dim bg-transparent hover:text-black dark:hover:text-white"

--- a/apps/app/dashboards/demography/immigration/index.tsx
+++ b/apps/app/dashboards/demography/immigration/index.tsx
@@ -1,19 +1,85 @@
-import AgencyBadge from "@components/Badge/agency";
-import { Hero } from "@components/index";
-import { useTranslation } from "@hooks/useTranslation";
-import { FunctionComponent } from "react";
-import Container from "@components/Container";
+import {
+  AgencyBadge,
+  ComboBox,
+  Container,
+  Dropdown,
+  Hero,
+  LeftRightCard,
+  Section,
+} from "@components/index";
+import Slider from "@components/Chart/Slider";
+import { SliderProvider } from "@components/Chart/Slider/context";
 import { JIMIcon } from "@components/Icon/agency";
+import { OptionType } from "@components/types";
+import { useData } from "@hooks/useData";
+import { useSlice } from "@hooks/useSlice";
+import { useTranslation } from "@hooks/useTranslation";
+import { getTopIndices, numFormat, toDate } from "@lib/helpers";
+import dynamic from "next/dynamic";
+import { FunctionComponent } from "react";
+import { AKSARA_COLOR, CountryAndStates } from "@lib/constants";
+import { ArrowRightIcon } from "@heroicons/react/20/solid";
+import { get } from "@lib/api";
 
 /**
  * Immigration Dashboard
  * @overview Status: In-development
  */
 
-interface ImmigrationProps {}
+const Choropleth = dynamic(() => import("@components/Chart/Choropleth"), { ssr: false });
+const Timeseries = dynamic(() => import("@components/Chart/Timeseries"), { ssr: false });
 
-const Immigration: FunctionComponent<ImmigrationProps> = ({}) => {
+interface ImmigrationProps {
+  choropleth: any;
+  countries: any;
+  last_updated: any;
+  timeseries: any;
+  timeseries_callout: any;
+  timeseries_country: any;
+  timeseries_country_callout: any;
+}
+
+const Immigration: FunctionComponent<ImmigrationProps> = ({
+  choropleth,
+  countries,
+  last_updated,
+  timeseries,
+  timeseries_callout,
+  timeseries_country,
+  timeseries_country_callout,
+}) => {
   const { t, i18n } = useTranslation(["dashboard-immigration", "common"]);
+  const COUNTRY_OPTIONS: Array<OptionType> = countries.map((key: string) => ({
+    label: t(key),
+    value: key,
+  }));
+  const FILTER_OPTIONS: Array<OptionType> = [
+    "absolute",
+    "absolute_adult",
+    "absolute_children",
+    "per_capita",
+    "per_capita_adult",
+    "per_capita_children",
+  ].map((key: string) => ({
+    label: t(`${key}`),
+    value: key,
+  }));
+  const { data, setData } = useData({
+    timeseries_country: timeseries_country,
+    timeseries_country_callout: timeseries_country_callout,
+    minmax: [0, timeseries.data.data.x.length],
+    country_minmax: [0, timeseries_country.data.x.length],
+    country: COUNTRY_OPTIONS[0],
+    country_label: "AFG",
+    filter: FILTER_OPTIONS[0],
+  });
+  const { coordinate } = useSlice(timeseries.data.data, data.minmax);
+  const { coordinate: coordinate_country } = useSlice(
+    data.timeseries_country.data,
+    data.country_minmax
+  );
+  const PASS = ["expatriate", "visit", "entry"];
+  const topStateIndices = getTopIndices(choropleth.data[data.filter.value].y.value, 3, true);
 
   return (
     <>
@@ -24,14 +90,277 @@ const Immigration: FunctionComponent<ImmigrationProps> = ({}) => {
         description={[t("description")]}
         agencyBadge={
           <AgencyBadge
-            agency={"Immigration Department of Malaysia"}
+            agency={t("common:agency.Imigresen")}
             link="https://www.jpn.gov.my/en/"
             icon={<JIMIcon />}
           />
         }
+        last_updated={last_updated}
       />
-      {/* Rest of page goes here */}
-      <Container className="min-h-screen"></Container>
+
+      <Container className="min-h-screen">
+        <div className="grid w-full grid-cols-12 pt-12 lg:grid-cols-10">
+          <div className="col-span-10 col-start-2 sm:col-span-8 sm:col-start-3 md:col-span-6 md:col-start-4 lg:col-span-4 lg:col-start-4">
+            <ComboBox
+              placeholder={t("search_country")}
+              options={COUNTRY_OPTIONS}
+              selected={
+                data.country ? COUNTRY_OPTIONS.find(e => e.value === data.country.value) : undefined
+              }
+              onChange={country => {
+                setData("country", country);
+                if (country) {
+                  get("/dashboard", { dashboard: "immigration", country: country.value })
+                    .then(({ data }) => {
+                      console.log(data);
+                      setData("timeseries_country", data.timeseries_country);
+                      setData("timeseries_country_callout", data.timeseries_country_callout);
+                    })
+                    .catch(e => {
+                      console.error(e);
+                    });
+                  setData("country_label", country.label);
+                }
+              }}
+            />
+          </div>
+        </div>
+        {/* How many people from {{ country }} are entering and leaving the country? */}
+        <Section
+          title={t("country_header", { country: data.country_label })}
+          date={timeseries.data_as_of}
+        >
+          <SliderProvider>
+            {play => (
+              <>
+                <Timeseries
+                  className="h-[600px] w-full"
+                  title={t("country_title")}
+                  enableAnimation={!play}
+                  interval="day"
+                  data={{
+                    labels: coordinate_country.x,
+                    datasets: [
+                      {
+                        type: "line",
+                        data: coordinate_country.daily,
+                        label: t("entrances"),
+                        backgroundColor: AKSARA_COLOR.PURPLE_H,
+                        borderColor: AKSARA_COLOR.PURPLE,
+                        borderWidth: 1.5,
+                        fill: true,
+                      },
+                      {
+                        type: "line",
+                        data: coordinate_country.daily.map((n: number) => (n > 0 ? -n : n)),
+                        label: t("departures"),
+                        backgroundColor: AKSARA_COLOR.PURPLE_H,
+                        borderColor: AKSARA_COLOR.PURPLE,
+                        borderWidth: 1.5,
+                        fill: true,
+                      },
+                    ],
+                  }}
+                  stats={[
+                    {
+                      title: t("entrances"),
+                      value: `+${numFormat(
+                        data.timeseries_country_callout.data["entrances"].value,
+                        "standard"
+                      )}`,
+                    },
+                    {
+                      title: t("departures"),
+                      value: `-${numFormat(
+                        data.timeseries_country_callout.data["departures"].value,
+                        "standard"
+                      )}`,
+                    },
+                    {
+                      title: t("net_migration"),
+                      value: `${numFormat(
+                        data.timeseries_country_callout.data["net_migration"].value,
+                        "standard"
+                      )}`,
+                    },
+                  ]}
+                />
+                <Slider
+                  type="range"
+                  value={data.country_minmax}
+                  data={timeseries_country.data.x}
+                  onChange={e => setData("country_minmax", e)}
+                />
+              </>
+            )}
+          </SliderProvider>
+        </Section>
+        <Section>
+          <LeftRightCard
+            left={
+              <div className="flex h-full w-full flex-col space-y-6 p-8">
+                <div className="flex flex-col gap-2">
+                  <h4>{t("choro_header")}</h4>
+                  <span className="font-dim text-sm">
+                    {t("common:common.data_of", {
+                      date: toDate(choropleth.data_as_of, "dd MMM yyyy, HH:mm", i18n.language),
+                    })}
+                  </span>
+                </div>
+                <Dropdown
+                  anchor="left"
+                  className="w-fit"
+                  placeholder={t("common:common.select")}
+                  options={FILTER_OPTIONS}
+                  selected={FILTER_OPTIONS.find(e => e.value === data.filter.value)}
+                  onChange={e => setData("filter", e)}
+                />
+                <div className="flex grow flex-col justify-between space-y-6">
+                  <p className="text-dim">{t("choro_description")}</p>
+                  <div className="space-y-3 border-t pt-6">
+                    <p className="font-bold">{t("choro_ranking")}</p>
+                    {topStateIndices.map((pos, i) => {
+                      return (
+                        <div className="flex space-x-3" key={pos}>
+                          <div className="text-dim font-medium">#{i + 1}</div>
+                          <div className="grow">
+                            {CountryAndStates[choropleth.data[data.filter.value].x[pos]]}
+                          </div>
+                          <div className="text-purple font-bold">
+                            {numFormat(choropleth.data[data.filter.value].y.value[pos], "standard")}
+                          </div>
+                          <ArrowRightIcon className="text-dim h-4 w-4 self-center stroke-[1.5px]" />
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            }
+            right={
+              <>
+                <Choropleth
+                  className="h-[400px] w-auto rounded-b lg:h-[500px] lg:w-full"
+                  data={{
+                    labels: choropleth.data[data.filter.value].x.map(
+                      (state: string) => CountryAndStates[state]
+                    ),
+                    values: choropleth.data[data.filter.value].y.value,
+                  }}
+                  type="state"
+                  color="purples"
+                />
+              </>
+            }
+          />
+        </Section>
+        {/* How are the Immigration Department’s counter operations trending? */}
+        <Section title={t("timeseries_header")}>
+          <SliderProvider>
+            {play => (
+              <>
+                <Timeseries
+                  className="h-[300px] w-full"
+                  title={t("passport")}
+                  enableAnimation={!play}
+                  interval="day"
+                  data={{
+                    labels: coordinate.x,
+                    datasets: [
+                      {
+                        type: "line",
+                        data: coordinate.passport,
+                        label: t("entrances"),
+                        backgroundColor: AKSARA_COLOR.PURPLE_H,
+                        borderColor: AKSARA_COLOR.PURPLE,
+                        borderWidth: 1.5,
+                        fill: true,
+                      },
+                    ],
+                  }}
+                  stats={[
+                    {
+                      title: t("daily"),
+                      value: `+${numFormat(
+                        timeseries_callout.data.data["passport"].daily.value,
+                        "standard"
+                      )}`,
+                    },
+                    {
+                      title: t("this_year"),
+                      value: `+${numFormat(
+                        timeseries_callout.data.data["passport"].year.value,
+                        "standard"
+                      )}`,
+                    },
+                    {
+                      title: t("active_passports"),
+                      value: `+${numFormat(
+                        timeseries_callout.data.data["passport"].pass.value,
+                        "standard"
+                      )}`,
+                    },
+                  ]}
+                />
+                <Slider
+                  type="range"
+                  value={data.minmax}
+                  data={timeseries.data.data.x}
+                  onChange={e => setData("minmax", e)}
+                />
+                <div className="grid grid-cols-1 gap-12 pt-12 lg:grid-cols-3">
+                  {PASS.map((key: string, index: number) => (
+                    <Timeseries
+                      key={key}
+                      title={t(`${key}`)}
+                      className="h-[300px] w-full"
+                      enableAnimation={!play}
+                      interval="day"
+                      data={{
+                        labels: coordinate.x,
+                        datasets: [
+                          {
+                            type: "line",
+                            data: coordinate[key],
+                            label: t("daily"),
+                            backgroundColor: AKSARA_COLOR.PURPLE_H,
+                            borderColor: AKSARA_COLOR.PURPLE,
+                            borderWidth: 1.5,
+                            fill: true,
+                          },
+                        ],
+                      }}
+                      stats={[
+                        {
+                          title: t("daily"),
+                          value: `+${numFormat(
+                            timeseries_callout.data.data[key].daily.value,
+                            "standard"
+                          )}`,
+                        },
+                        {
+                          title: t("this_year"),
+                          value: `${numFormat(
+                            timeseries_callout.data.data[key].year.value,
+                            "standard"
+                          )}`,
+                        },
+                        {
+                          title: index === 2 ? t("active_permits") : t("active_passes"),
+                          value: `${numFormat(
+                            timeseries_callout.data.data[key].pass.value,
+                            "standard"
+                          )}`,
+                        },
+                      ]}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+          </SliderProvider>
+        </Section>
+      </Container>
     </>
   );
 };

--- a/apps/app/dashboards/demography/immigration/index.tsx
+++ b/apps/app/dashboards/demography/immigration/index.tsx
@@ -6,6 +6,7 @@ import {
   Hero,
   LeftRightCard,
   Section,
+  Tabs,
 } from "@components/index";
 import Slider from "@components/Chart/Slider";
 import { SliderProvider } from "@components/Chart/Slider/context";
@@ -20,6 +21,8 @@ import { FunctionComponent } from "react";
 import { AKSARA_COLOR, CountryAndStates } from "@lib/constants";
 import { ArrowRightIcon } from "@heroicons/react/20/solid";
 import { get } from "@lib/api";
+import { useTheme } from "next-themes";
+import { GlobeAltIcon } from "@heroicons/react/24/outline";
 
 /**
  * Immigration Dashboard
@@ -48,9 +51,10 @@ const Immigration: FunctionComponent<ImmigrationProps> = ({
   timeseries_country,
   timeseries_country_callout,
 }) => {
-  const { t, i18n } = useTranslation(["dashboard-immigration", "common"]);
+  const { t, i18n } = useTranslation(["dashboard-immigration", "common", "countries"]);
+  const { theme } = useTheme();
   const COUNTRY_OPTIONS: Array<OptionType> = countries.map((key: string) => ({
-    label: t(key),
+    label: t(`countries:${key}`),
     value: key,
   }));
   const FILTER_OPTIONS: Array<OptionType> = [
@@ -65,17 +69,29 @@ const Immigration: FunctionComponent<ImmigrationProps> = ({
     value: key,
   }));
   const { data, setData } = useData({
+    tabs_section_2: 0,
+    tabs_section_3: 0,
+    timeseries: timeseries,
+    timeseries_callout: timeseries_callout,
     timeseries_country: timeseries_country,
     timeseries_country_callout: timeseries_country_callout,
-    minmax: [0, timeseries.data.data.x.length],
-    country_minmax: [0, timeseries_country.data.x.length],
-    country: COUNTRY_OPTIONS[0],
-    country_label: "AFG",
+    minmax: [0, timeseries.data.data.day.x.length],
+    country_minmax: [0, timeseries_country.data.day.x.length],
+    country: COUNTRY_OPTIONS.find(e => e.value === "overall"),
+    country_label: t("countries:overall"),
     filter: FILTER_OPTIONS[0],
   });
-  const { coordinate } = useSlice(timeseries.data.data, data.minmax);
+  const period: { [key: number]: "day" | "month" | "year" } = {
+    0: "day",
+    1: "month",
+    2: "year",
+  };
+  const { coordinate } = useSlice(
+    data.timeseries.data.data[period[data.tabs_section_3]],
+    data.minmax
+  );
   const { coordinate: coordinate_country } = useSlice(
-    data.timeseries_country.data,
+    data.timeseries_country.data[period[data.tabs_section_2]],
     data.country_minmax
   );
   const PASS = ["expatriate", "visit", "entry"];
@@ -99,102 +115,6 @@ const Immigration: FunctionComponent<ImmigrationProps> = ({
       />
 
       <Container className="min-h-screen">
-        <div className="grid w-full grid-cols-12 pt-12 lg:grid-cols-10">
-          <div className="col-span-10 col-start-2 sm:col-span-8 sm:col-start-3 md:col-span-6 md:col-start-4 lg:col-span-4 lg:col-start-4">
-            <ComboBox
-              placeholder={t("search_country")}
-              options={COUNTRY_OPTIONS}
-              selected={
-                data.country ? COUNTRY_OPTIONS.find(e => e.value === data.country.value) : undefined
-              }
-              onChange={country => {
-                setData("country", country);
-                if (country) {
-                  get("/dashboard", { dashboard: "immigration", country: country.value })
-                    .then(({ data }) => {
-                      console.log(data);
-                      setData("timeseries_country", data.timeseries_country);
-                      setData("timeseries_country_callout", data.timeseries_country_callout);
-                    })
-                    .catch(e => {
-                      console.error(e);
-                    });
-                  setData("country_label", country.label);
-                }
-              }}
-            />
-          </div>
-        </div>
-        {/* How many people from {{ country }} are entering and leaving the country? */}
-        <Section
-          title={t("country_header", { country: data.country_label })}
-          date={timeseries.data_as_of}
-        >
-          <SliderProvider>
-            {play => (
-              <>
-                <Timeseries
-                  className="h-[600px] w-full"
-                  title={t("country_title")}
-                  enableAnimation={!play}
-                  interval="day"
-                  data={{
-                    labels: coordinate_country.x,
-                    datasets: [
-                      {
-                        type: "line",
-                        data: coordinate_country.daily,
-                        label: t("entrances"),
-                        backgroundColor: AKSARA_COLOR.PURPLE_H,
-                        borderColor: AKSARA_COLOR.PURPLE,
-                        borderWidth: 1.5,
-                        fill: true,
-                      },
-                      {
-                        type: "line",
-                        data: coordinate_country.daily.map((n: number) => (n > 0 ? -n : n)),
-                        label: t("departures"),
-                        backgroundColor: AKSARA_COLOR.PURPLE_H,
-                        borderColor: AKSARA_COLOR.PURPLE,
-                        borderWidth: 1.5,
-                        fill: true,
-                      },
-                    ],
-                  }}
-                  stats={[
-                    {
-                      title: t("entrances"),
-                      value: `+${numFormat(
-                        data.timeseries_country_callout.data["entrances"].value,
-                        "standard"
-                      )}`,
-                    },
-                    {
-                      title: t("departures"),
-                      value: `-${numFormat(
-                        data.timeseries_country_callout.data["departures"].value,
-                        "standard"
-                      )}`,
-                    },
-                    {
-                      title: t("net_migration"),
-                      value: `${numFormat(
-                        data.timeseries_country_callout.data["net_migration"].value,
-                        "standard"
-                      )}`,
-                    },
-                  ]}
-                />
-                <Slider
-                  type="range"
-                  value={data.country_minmax}
-                  data={timeseries_country.data.x}
-                  onChange={e => setData("country_minmax", e)}
-                />
-              </>
-            )}
-          </SliderProvider>
-        </Section>
         <Section>
           <LeftRightCard
             left={
@@ -254,8 +174,169 @@ const Immigration: FunctionComponent<ImmigrationProps> = ({
             }
           />
         </Section>
+
+        {/* How many people from {{ country }} are entering and leaving the country? */}
+        <Section
+        // date={timeseries.data_as_of}
+        >
+          <>
+            <div className="w-full space-y-12">
+              <div className="w-full space-y-6">
+                <h4 className="text-center">
+                  {t("country_header", {
+                    country: data.country_label,
+                    context: data.country_label && "overall",
+                  })}
+                </h4>
+                <div className="flex flex-col items-center justify-center space-y-3">
+                  <div className="grid w-full grid-cols-12 lg:grid-cols-10">
+                    <div className="col-span-10 col-start-2 sm:col-span-8 sm:col-start-3 md:col-span-6 md:col-start-4 lg:col-span-4 lg:col-start-4">
+                      <ComboBox
+                        enableFlag
+                        imageSource="https://flagcdn.com/h20/"
+                        fallback={<GlobeAltIcon className="w-4.5 h-4.5 mx-auto text-black" />}
+                        placeholder={t("search_country")}
+                        options={COUNTRY_OPTIONS}
+                        selected={
+                          data.country
+                            ? COUNTRY_OPTIONS.find(e => e.value === data.country.value)
+                            : undefined
+                        }
+                        onChange={country => {
+                          setData("country", country);
+                          if (country) {
+                            get("/dashboard", {
+                              dashboard: "immigration_country",
+                              country: country.value,
+                            })
+                              .then(({ data }) => {
+                                if (data.timeseries_country && data.timeseries_country_callout) {
+                                  setData("timeseries_country", data.timeseries_country);
+                                  setData(
+                                    "timeseries_country_callout",
+                                    data.timeseries_country_callout
+                                  );
+                                }
+                                setData("country_label", country.label);
+                              })
+                              .catch(e => {
+                                console.error(e);
+                              });
+                          }
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <p className="text-dim text-center text-sm">{t("country_desc")}</p>
+                </div>
+              </div>
+
+              <SliderProvider>
+                {play => (
+                  <div>
+                    <div className="pb-3">
+                      <Tabs.List
+                        options={[t("day"), t("month"), t("year")]}
+                        current={data.tabs_section_2}
+                        onChange={index => {
+                          setData("tabs_section_2", index);
+                        }}
+                      />
+                    </div>
+                    <Timeseries
+                      title={t("country_title")}
+                      className="h-[400px] w-full"
+                      enableAnimation={!play}
+                      mode="grouped"
+                      interval={period[data.tabs_section_2]}
+                      round={period[data.tabs_section_2]}
+                      data={{
+                        labels: coordinate_country.x,
+                        datasets: [
+                          {
+                            type: "line",
+                            data: coordinate_country.immigration,
+                            label: t("entrances"),
+                            backgroundColor: AKSARA_COLOR.PURPLE_H,
+                            borderColor: AKSARA_COLOR.PURPLE,
+                            borderWidth: 1.5,
+                            fill: true,
+                          },
+                          {
+                            type: "line",
+                            data: coordinate_country.emigration,
+                            label: t("departures"),
+                            backgroundColor: AKSARA_COLOR.DIM_H,
+                            borderColor: AKSARA_COLOR.DIM,
+                            borderWidth: 1.5,
+                            fill: true,
+                          },
+                          {
+                            type: "line",
+                            data: coordinate_country.net_migration,
+                            label: t("net_migration"),
+                            backgroundColor:
+                              theme === "light" ? AKSARA_COLOR.BLACK_H : AKSARA_COLOR.WHITE,
+                            borderColor:
+                              theme === "light" ? AKSARA_COLOR.BLACK : AKSARA_COLOR.WHITE,
+                            borderDash: [2, 2],
+                            borderWidth: 1.5,
+                            fill: true,
+                          },
+                        ],
+                      }}
+                      stats={[
+                        {
+                          title: t("entrances"),
+                          value: `+${numFormat(
+                            data.timeseries_country_callout.data["entrances"].value,
+                            "standard"
+                          )}`,
+                        },
+                        {
+                          title: t("departures"),
+                          value: `-${numFormat(
+                            data.timeseries_country_callout.data["departures"].value,
+                            "standard"
+                          )}`,
+                        },
+                        {
+                          title: t("net_migration"),
+                          value: `${numFormat(
+                            data.timeseries_country_callout.data["net_migration"].value,
+                            "standard"
+                          )}`,
+                        },
+                      ]}
+                    />
+                    <Slider
+                      type="range"
+                      period={period[data.tabs_section_2]}
+                      value={data.country_minmax}
+                      data={data.timeseries_country.data[period[data.tabs_section_2]].x}
+                      onChange={e => setData("country_minmax", e)}
+                    />
+                  </div>
+                )}
+              </SliderProvider>
+            </div>
+          </>
+        </Section>
         {/* How are the Immigration Department’s counter operations trending? */}
-        <Section title={t("timeseries_header")}>
+        <Section
+          title={t("timeseries_header")}
+          date={timeseries_country.data_as_of}
+          description={t("timeseries_desc")}
+          menu={
+            <Tabs.List
+              options={[t("day"), t("month"), t("year")]}
+              current={data.tabs_section_3}
+              onChange={index => {
+                setData("tabs_section_3", index);
+              }}
+            />
+          }
+        >
           <SliderProvider>
             {play => (
               <>
@@ -263,14 +344,15 @@ const Immigration: FunctionComponent<ImmigrationProps> = ({
                   className="h-[300px] w-full"
                   title={t("passport")}
                   enableAnimation={!play}
-                  interval="day"
+                  interval={period[data.tabs_section_3]}
+                  round={period[data.tabs_section_3]}
                   data={{
                     labels: coordinate.x,
                     datasets: [
                       {
                         type: "line",
                         data: coordinate.passport,
-                        label: t("entrances"),
+                        label: t(period[data.tabs_section_3]),
                         backgroundColor: AKSARA_COLOR.PURPLE_H,
                         borderColor: AKSARA_COLOR.PURPLE,
                         borderWidth: 1.5,
@@ -288,15 +370,15 @@ const Immigration: FunctionComponent<ImmigrationProps> = ({
                     },
                     {
                       title: t("this_year"),
-                      value: `+${numFormat(
+                      value: `${numFormat(
                         timeseries_callout.data.data["passport"].year.value,
                         "standard"
                       )}`,
                     },
                     {
                       title: t("active_passports"),
-                      value: `+${numFormat(
-                        timeseries_callout.data.data["passport"].pass.value,
+                      value: `${numFormat(
+                        timeseries_callout.data.data["passport"].active.value,
                         "standard"
                       )}`,
                     },
@@ -304,8 +386,9 @@ const Immigration: FunctionComponent<ImmigrationProps> = ({
                 />
                 <Slider
                   type="range"
+                  period={period[data.tabs_section_3]}
                   value={data.minmax}
-                  data={timeseries.data.data.x}
+                  data={timeseries.data.data[period[data.tabs_section_3]].x}
                   onChange={e => setData("minmax", e)}
                 />
                 <div className="grid grid-cols-1 gap-12 pt-12 lg:grid-cols-3">
@@ -315,14 +398,15 @@ const Immigration: FunctionComponent<ImmigrationProps> = ({
                       title={t(`${key}`)}
                       className="h-[300px] w-full"
                       enableAnimation={!play}
-                      interval="day"
+                      interval={period[data.tabs_section_3]}
+                      round={period[data.tabs_section_3]}
                       data={{
                         labels: coordinate.x,
                         datasets: [
                           {
                             type: "line",
                             data: coordinate[key],
-                            label: t("daily"),
+                            label: t(period[data.tabs_section_3]),
                             backgroundColor: AKSARA_COLOR.PURPLE_H,
                             borderColor: AKSARA_COLOR.PURPLE,
                             borderWidth: 1.5,
@@ -348,7 +432,7 @@ const Immigration: FunctionComponent<ImmigrationProps> = ({
                         {
                           title: index === 2 ? t("active_permits") : t("active_passes"),
                           value: `${numFormat(
-                            timeseries_callout.data.data[key].pass.value,
+                            timeseries_callout.data.data[key].active.value,
                             "standard"
                           )}`,
                         },

--- a/apps/app/next-i18next.config.js
+++ b/apps/app/next-i18next.config.js
@@ -3,6 +3,7 @@ const I18NextHttpBackend = require("i18next-http-backend");
 const namespace = [
   "common",
   "catalogue",
+  "countries",
   "dashboard-999-tracker",
   "dashboard-birthday-explorer",
   "dashboard-blood-donation",

--- a/apps/app/next.config.js
+++ b/apps/app/next.config.js
@@ -55,6 +55,16 @@ const nextConfig = {
       },
     ];
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "flagcdn.com",
+        port: "",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 module.exports = () => {

--- a/apps/app/pages/dashboard/immigration/index.tsx
+++ b/apps/app/pages/dashboard/immigration/index.tsx
@@ -16,7 +16,7 @@ const Immigration: Page = ({
   timeseries_country,
   timeseries_country_callout,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
-  const { t } = useTranslation(["dashboard-immigration", "common"]);
+  const { t } = useTranslation(["dashboard-immigration", "common", "countries"]);
 
   return (
     <>
@@ -34,28 +34,35 @@ const Immigration: Page = ({
   );
 };
 
-export const getStaticProps: GetStaticProps = withi18n("dashboard-immigration", async () => {
-  const { data: dropdown } = await get("/dropdown", { dashboard: "immigration" });
-  const { data } = await get("/dashboard", { dashboard: "immigration", country: "AFG" });
+export const getStaticProps: GetStaticProps = withi18n(
+  ["dashboard-immigration", "countries"],
+  async () => {
+    const { data: dropdown } = await get("/dropdown", { dashboard: "immigration" });
+    const { data } = await get("/dashboard", {
+      dashboard: "immigration",
+      country: "overall",
+      period: "daily",
+    });
 
-  return {
-    notFound: false,
-    props: {
-      meta: {
-        id: "dashboard-immigration",
-        type: "dashboard",
-        category: "demography",
-        agency: "Imigresen",
+    return {
+      notFound: false,
+      props: {
+        meta: {
+          id: "dashboard-immigration",
+          type: "dashboard",
+          category: "demography",
+          agency: "Imigresen",
+        },
+        choropleth: data.choropleth,
+        countries: dropdown.data,
+        last_updated: new Date().valueOf(),
+        timeseries: data.timeseries,
+        timeseries_callout: data.timeseries_callout,
+        timeseries_country: data.timeseries_country,
+        timeseries_country_callout: data.timeseries_country_callout,
       },
-      choropleth: data.choropleth,
-      countries: dropdown.data,
-      last_updated: new Date().valueOf(),
-      timeseries: data.timeseries,
-      timeseries_callout: data.timeseries_callout,
-      timeseries_country: data.timeseries_country,
-      timeseries_country_callout: data.timeseries_country_callout,
-    },
-  };
-});
+    };
+  }
+);
 
 export default Immigration;

--- a/apps/app/pages/dashboard/immigration/index.tsx
+++ b/apps/app/pages/dashboard/immigration/index.tsx
@@ -7,19 +7,36 @@ import { useTranslation } from "@hooks/useTranslation";
 import ImmigrationDashboard from "@dashboards/demography/immigration";
 import { withi18n } from "@lib/decorators";
 
-const Immigration: Page = ({}: InferGetStaticPropsType<typeof getStaticProps>) => {
+const Immigration: Page = ({
+  choropleth,
+  countries,
+  last_updated,
+  timeseries,
+  timeseries_callout,
+  timeseries_country,
+  timeseries_country_callout,
+}: InferGetStaticPropsType<typeof getStaticProps>) => {
   const { t } = useTranslation(["dashboard-immigration", "common"]);
 
   return (
     <>
       <Metadata title={t("header")} description={t("description")} keywords={""} />
-      <ImmigrationDashboard />
+      <ImmigrationDashboard
+        choropleth={choropleth}
+        countries={countries}
+        last_updated={last_updated}
+        timeseries={timeseries}
+        timeseries_callout={timeseries_callout}
+        timeseries_country={timeseries_country}
+        timeseries_country_callout={timeseries_country_callout}
+      />
     </>
   );
 };
-// Disabled
+
 export const getStaticProps: GetStaticProps = withi18n("dashboard-immigration", async () => {
-  //   const { data } = await get("/dashboard", { dashboard: "currency" });
+  const { data: dropdown } = await get("/dropdown", { dashboard: "immigration" });
+  const { data } = await get("/dashboard", { dashboard: "immigration", country: "AFG" });
 
   return {
     notFound: false,
@@ -30,6 +47,13 @@ export const getStaticProps: GetStaticProps = withi18n("dashboard-immigration", 
         category: "demography",
         agency: "Imigresen",
       },
+      choropleth: data.choropleth,
+      countries: dropdown.data,
+      last_updated: new Date().valueOf(),
+      timeseries: data.timeseries,
+      timeseries_callout: data.timeseries_callout,
+      timeseries_country: data.timeseries_country,
+      timeseries_country_callout: data.timeseries_country_callout,
     },
   };
 });

--- a/apps/app/pages/dashboard/immigration/index.tsx
+++ b/apps/app/pages/dashboard/immigration/index.tsx
@@ -37,13 +37,14 @@ const Immigration: Page = ({
 export const getStaticProps: GetStaticProps = withi18n(
   ["dashboard-immigration", "countries"],
   async () => {
-    const { data: dropdown } = await get("/dropdown", { dashboard: "immigration" });
+    const { data: dropdown } = await get("/dropdown", { dashboard: "immigration_country" });
     const { data } = await get("/dashboard", {
       dashboard: "immigration",
-      country: "overall",
-      period: "daily",
     });
-
+    const { data: country } = await get("/dashboard", {
+      dashboard: "immigration_country",
+      country: "overall",
+    });
     return {
       notFound: false,
       props: {
@@ -58,8 +59,8 @@ export const getStaticProps: GetStaticProps = withi18n(
         last_updated: new Date().valueOf(),
         timeseries: data.timeseries,
         timeseries_callout: data.timeseries_callout,
-        timeseries_country: data.timeseries_country,
-        timeseries_country_callout: data.timeseries_country_callout,
+        timeseries_country: country.timeseries_country,
+        timeseries_country_callout: country.timeseries_country_callout,
       },
     };
   }


### PR DESCRIPTION
### Changes
#### `Immigration` Dashboard 
- add `countries` to i18n namespace
- use Flagpedia's API for country flags
- add flagcdn.com to allowed hostname in next config
- customisable `Fallback` for `ImageWithFallback`

EDIT: Removed `Section` changes