### PR TITLE
Fix/election

### DIFF
--- a/apps/app/components/Accordion/index.tsx
+++ b/apps/app/components/Accordion/index.tsx
@@ -11,7 +11,7 @@ type AccordionProps = {
 };
 
 const Accordion: FunctionComponent<AccordionProps> = ({
-  className = "p-4 border border-outline dark:border-washed-dark shadow",
+  className,
   width = "w-full",
   icon,
   title,
@@ -25,7 +25,8 @@ const Accordion: FunctionComponent<AccordionProps> = ({
             <div
               className={clx(
                 open ? "rounded-none" : "rounded-b-xl",
-                "hover:border-outlineHover dark:hover:border-outlineHover-dark hover:bg-washed dark:hover:bg-washed-dark cursor-pointer rounded-t-xl",
+                "hover:bg-washed dark:hover:bg-washed-dark cursor-pointer rounded-t-xl p-4 shadow",
+                "border-outline dark:border-washed-dark hover:border-outlineHover dark:hover:border-outlineHover-dark border",
                 width,
                 className
               )}
@@ -48,9 +49,8 @@ const Accordion: FunctionComponent<AccordionProps> = ({
             <Disclosure.Panel>
               <div
                 className={clx(
-                  "text-dim rounded-b-xl border border-t-0 font-normal",
-                  width,
-                  className
+                  "text-dim border-outline dark:border-washed-dark rounded-b-xl border border-t-0 p-4 font-normal shadow",
+                  width
                 )}
               >
                 {children}

--- a/apps/app/components/Card/ElectionCard.tsx
+++ b/apps/app/components/Card/ElectionCard.tsx
@@ -37,7 +37,7 @@ interface ElectionCardProps<T extends Candidate | Party | Seat> {
   columns?: any;
   title?: string | ReactElement;
   subtitle?: boolean;
-  highlightedRow?: false | number;
+  highlighted?: string;
   page: number;
 }
 
@@ -48,13 +48,14 @@ const ElectionCard = <T extends Candidate | Party | Seat>({
   columns,
   title,
   subtitle = false,
-  highlightedRow,
+  highlighted,
   page,
 }: ElectionCardProps<T>) => {
   const [show, setShow] = useState<boolean>(false);
   const { data, setData } = useData({
     index: page,
     result: [],
+
     loading: false,
   });
   const { t, i18n } = useTranslation(["dashboard-election-explorer", "common"]);
@@ -144,7 +145,18 @@ const ElectionCard = <T extends Candidate | Party | Seat>({
                         data={data.result.data}
                         columns={columns}
                         isLoading={data.loading}
-                        highlightedRow={highlightedRow}
+                        highlightedRow={
+                          data.result.data && highlighted
+                            ? "name" in data.result.data[0]
+                              ? data.result.data.findIndex(
+                                  (e: BaseResult) => e.name === highlighted
+                                )
+                              : "party" in data.result.data[0] &&
+                                data.result.data.findIndex(
+                                  (e: BaseResult) => e.party === highlighted
+                                )
+                            : 0
+                        }
                         win={"result" in defaultParams ? defaultParams.result : undefined}
                       />
                     </div>

--- a/apps/app/components/Card/ElectionCard.tsx
+++ b/apps/app/components/Card/ElectionCard.tsx
@@ -157,7 +157,7 @@ const ElectionCard = <T extends Candidate | Party | Seat>({
                                 )
                             : 0
                         }
-                        win={"result" in defaultParams ? defaultParams.result : undefined}
+                        result={"result" in defaultParams ? defaultParams.result : undefined}
                       />
                     </div>
 

--- a/apps/app/components/Card/ElectionCard.tsx
+++ b/apps/app/components/Card/ElectionCard.tsx
@@ -167,7 +167,7 @@ const ElectionCard = <T extends Candidate | Party | Seat>({
                         <div className="flex flex-col gap-3 text-sm md:flex-row md:flex-wrap md:gap-x-6">
                           {data.result.votes.map(
                             (item: { x: string; abs: number; perc: number }) => (
-                              <div className="flex space-x-3 whitespace-nowrap">
+                              <div className="flex space-x-3 whitespace-nowrap" key={item.x}>
                                 <p className="w-28 md:w-fit">{t(`election.${item.x}`)}:</p>
                                 <div className="flex items-center space-x-3">
                                   <BarPerc hidden value={item.perc} size={"h-[5px] w-[50px]"} />

--- a/apps/app/components/Card/ElectionCard.tsx
+++ b/apps/app/components/Card/ElectionCard.tsx
@@ -10,7 +10,7 @@ import {
 } from "@heroicons/react/24/solid";
 import { useTranslation } from "@hooks/useTranslation";
 import { Dialog, Transition } from "@headlessui/react";
-import { clx, toDate } from "@lib/helpers";
+import { clx, numFormat, toDate } from "@lib/helpers";
 import { useData } from "@hooks/useData";
 import type {
   BaseResult,
@@ -25,7 +25,8 @@ type Result<T> = {
   data: T;
   votes?: Array<{
     x: string;
-    y: number;
+    abs: number;
+    perc: number;
   }>;
 } | void;
 
@@ -35,6 +36,7 @@ interface ElectionCardProps<T extends Candidate | Party | Seat> {
   options: Array<T>;
   columns?: any;
   title?: string | ReactElement;
+  subtitle?: boolean;
   highlightedRow?: false | number;
   page: number;
 }
@@ -45,6 +47,7 @@ const ElectionCard = <T extends Candidate | Party | Seat>({
   options,
   columns,
   title,
+  subtitle = false,
   highlightedRow,
   page,
 }: ElectionCardProps<T>) => {
@@ -115,7 +118,7 @@ const ElectionCard = <T extends Candidate | Party | Seat>({
                   >
                     {title && typeof title === "string" ? <h5>{title}</h5> : title}
                     <button
-                      className="hover:bg-washed dark:hover:bg-washed-dark top-6.5 group absolute right-6 h-8 w-8 rounded-full"
+                      className="hover:bg-washed dark:hover:bg-washed-dark md:top-6.5 group absolute right-3 top-5 h-8 w-8 rounded-full md:right-6"
                       onClick={() => setShow(false)}
                     >
                       <XMarkIcon className="text-dim mx-auto h-6 w-6" />
@@ -124,32 +127,50 @@ const ElectionCard = <T extends Candidate | Party | Seat>({
 
                   <div className="space-y-6 text-base">
                     <div className="space-x-3 pt-2">
-                      <span className="text-dim">
-                        {toDate(options[data.index]?.date, "dd MMM yyyy", i18n.language)}
-                      </span>
-
-                      <span className="uppercase">{options[data.index]?.election_name}</span>
+                      {subtitle && (
+                        <>
+                          <span className="uppercase">{t(options[data.index]?.election_name)}</span>
+                          <span className="text-dim">
+                            {toDate(options[data.index]?.date, "dd MMM yyyy", i18n.language)}
+                          </span>
+                        </>
+                      )}
                     </div>
-                    <ElectionTable
-                      className="max-h-96 w-full overflow-y-auto"
-                      data={data.result.data}
-                      columns={columns}
-                      isLoading={data.loading}
-                      highlightedRow={highlightedRow}
-                      win={"result" in defaultParams ? defaultParams.result : undefined}
-                    />
+
+                    <div className="space-y-3">
+                      <div className="font-bold">{t("election.election_result")}</div>
+                      <ElectionTable
+                        className="max-h-96 w-full overflow-y-auto"
+                        data={data.result.data}
+                        columns={columns}
+                        isLoading={data.loading}
+                        highlightedRow={highlightedRow}
+                        win={"result" in defaultParams ? defaultParams.result : undefined}
+                      />
+                    </div>
 
                     {data.result.votes && (
-                      <div className="flex flex-row justify-center gap-6 px-0 md:gap-12 md:px-3">
-                        {data.result?.votes?.map((item: { x: string; y: number }) => (
-                          <BarPerc
-                            size="h-2.5 w-full"
-                            key={item.x}
-                            label={t(`election.${item.x}`)}
-                            value={item.y}
-                            className="w-full space-y-1 text-sm"
-                          />
-                        ))}
+                      <div className="space-y-3">
+                        <div className="font-bold">{t("election.voting_statistics")}</div>
+                        <div className="flex flex-col gap-3 text-sm md:flex-row md:flex-wrap md:gap-x-6">
+                          {data.result.votes.map(
+                            (item: { x: string; abs: number; perc: number }) => (
+                              <div className="flex space-x-3 whitespace-nowrap">
+                                <p className="w-28 md:w-fit">{t(`election.${item.x}`)}:</p>
+                                <div className="flex items-center space-x-3">
+                                  <BarPerc hidden value={item.perc} size={"h-[5px] w-[50px]"} />
+                                  <p>{`${
+                                    item.abs !== null ? numFormat(item.abs, "standard") : "—"
+                                  } ${
+                                    item.perc !== null
+                                      ? `(${numFormat(item.perc, "compact", [1, 1])}%)`
+                                      : "(—)"
+                                  }`}</p>
+                                </div>
+                              </div>
+                            )
+                          )}
+                        </div>
                       </div>
                     )}
 

--- a/apps/app/components/Chart/Table/ElectionTable.tsx
+++ b/apps/app/components/Chart/Table/ElectionTable.tsx
@@ -65,7 +65,7 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
           >
             {open => (
               <div
-                className="whitespace-nowrap underline decoration-dotted underline-offset-[3px]"
+                className="cursor-help whitespace-nowrap underline decoration-dotted underline-offset-[3px]"
                 tabIndex={0}
                 onClick={open}
               >

--- a/apps/app/components/Chart/Table/ElectionTable.tsx
+++ b/apps/app/components/Chart/Table/ElectionTable.tsx
@@ -55,6 +55,7 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
    * keys: party | election_name | seats | result | votes | majority
    */
   const lookupDesktop = (id: ElectionTableIds, cell: any) => {
+    const value = cell.getValue();
     switch (id) {
       case "election_name":
         return (
@@ -69,7 +70,7 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
                 tabIndex={0}
                 onClick={open}
               >
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                {t(value)}
               </div>
             )}
           </Tooltip>
@@ -78,19 +79,19 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
         return (
           <>
             <ImageWithFallback
-              className="border-outline dark:border-washed-dark aspect-4/3 absolute items-center self-center rounded border object-contain"
-              src={`/static/images/parties/${cell.getValue()}.png`}
+              className="border-outline dark:border-outlineHover-dark aspect-4/3 absolute rounded border object-contain"
+              src={`/static/images/parties/${value}.png`}
               width={32}
               height={32}
-              alt={t(`${cell.getValue()}`)}
+              alt={t(value)}
             />
             <span className="relative pl-10">
               {!table
                 .getAllColumns()
                 .map(col => col.id)
                 .includes("full_result")
-                ? t(cell.getValue())
-                : cell.getValue()}
+                ? t(value)
+                : value}
             </span>
           </>
         );
@@ -98,37 +99,26 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
         return (
           <div className="flex items-center gap-2 md:flex-col md:items-start lg:flex-row lg:items-center">
             <div>
-              <BarPerc hidden value={cell.getValue()?.perc} />
+              <BarPerc hidden value={value.perc} />
             </div>
-            <p className="whitespace-nowrap">{`${
-              cell.getValue().won === 0 ? "0" : cell.getValue().won + "/" + cell.getValue().total
-            } ${
-              cell.getValue().perc === 0
-                ? "(—)"
-                : `(${numFormat(cell.getValue().perc, "compact", [1, 1])}%)`
+            <p className="whitespace-nowrap">{`${value.won} / ${value.total} ${
+              value.perc !== null ? ` (${numFormat(value.perc, "compact", [1, 1])}%)` : " (—)"
             }`}</p>
           </div>
         );
       case "result":
-        return <ResultBadge value={cell.getValue()} />;
+        return <ResultBadge value={value} />;
 
       case "votes":
       case "majority":
         return (
-          <div
-            className={clx(
-              "z-0 flex gap-2",
-              cell.getValue().abs === 0 ? "flex-row items-center" : "md:flex-col lg:flex-row"
-            )}
-          >
+          <div className="flex items-center gap-2 md:flex-col md:items-start lg:flex-row lg:items-center">
             <div className="lg:self-center">
-              <BarPerc hidden value={cell.getValue()?.perc} />
+              <BarPerc hidden value={value.perc} />
             </div>
             <span className="whitespace-nowrap">
-              {cell.getValue().abs === 0 ? `—` : numFormat(cell.getValue().abs, "standard")}
-              {cell.getValue().perc === null
-                ? ` (—)`
-                : ` (${numFormat(cell.getValue().perc, "compact", [1, 1])}%)`}
+              {value.abs !== null ? numFormat(value.abs, "standard") : `—`}
+              {value.perc !== null ? ` (${numFormat(value.perc, "compact", [1, 1])}%)` : " (—)"}
             </span>
           </div>
         );
@@ -145,25 +135,23 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
         return (
           <div className="flex flex-row items-center gap-1.5">
             <ImageWithFallback
-              className="border-outline dark:border-washed-dark aspect-4/3 items-center self-center rounded border"
-              src={`/static/images/parties/${cell.getValue()}.png`}
+              className="border-outline dark:border-outlineHover-dark aspect-4/3 absolute rounded border object-contain"
+              src={`/static/images/parties/${value}.png`}
               width={32}
               height={18}
-              alt={t(cell.getValue())}
+              alt={t(value)}
             />
             {cell.row.original.name ? (
-              <span>{`${cell.row.original.name} (${cell.getValue()})`}</span>
+              <span className="relative pl-10">{`${cell.row.original.name} (${value})`}</span>
             ) : (
-              <span>{t(cell.getValue())}</span>
+              <span className="relative pl-10">{t(value)}</span>
             )}
           </div>
         );
       case "election_name":
         return (
           <div className="flex gap-3 text-sm">
-            <p className="font-medium">
-              {flexRender(cell.column.columnDef.cell, cell.getContext())}
-            </p>
+            <p className="font-medium">{t(value)}</p>
             {cell.row.original.date && (
               <p className="text-dim">
                 {toDate(cell.row.original.date, "dd MMM yyyy", i18n.language)}
@@ -180,10 +168,10 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
             <div className="flex items-center gap-2">
               <BarPerc hidden value={value?.perc} />
               <p>
-                {value?.won > 0
-                  ? `${numFormat(value?.won, "standard")}/${numFormat(value?.total, "standard")}`
-                  : "—"}
-                {value?.perc !== null ? ` (${numFormat(value?.perc, "compact", [1, 1])}%)` : " (—)"}
+                {`${value?.won} / ${value?.total}
+                 (${
+                   value?.perc !== null ? `${numFormat(value?.perc, "compact", [1, 1])}%` : "(—)"
+                 })`}
               </p>
             </div>
           </div>
@@ -195,9 +183,9 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
               {flexRender(cell.column.columnDef.header, cell.getContext())}
             </p>
             <div className="flex items-center gap-2">
-              <BarPerc hidden value={value?.perc} />
-              <p>{`${value?.abs > 0 ? numFormat(value?.abs, "standard") : "—"} (${
-                value?.perc !== null ? `${numFormat(value?.perc, "compact", [1, 1])}%` : "—"
+              <BarPerc hidden value={value.perc} />
+              <p>{`${value.abs !== null ? numFormat(value.abs, "standard") : "—"} (${
+                value.perc !== null ? `${numFormat(value.perc, "compact", [1, 1])}%` : "—"
               })`}</p>
             </div>
           </div>
@@ -209,9 +197,9 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
               {flexRender(cell.column.columnDef.header, cell.getContext())}
             </p>
             <div className="flex items-center gap-2">
-              <BarPerc hidden value={value?.perc} />
-              <p>{`${value?.abs > 0 ? numFormat(value?.abs, "standard") : "—"} (${
-                value?.perc !== null ? `${numFormat(value?.perc, "compact", [1, 1])}%` : "—"
+              <BarPerc hidden value={value.perc} />
+              <p>{`${value.abs !== null ? numFormat(value.abs, "standard") : "—"} (${
+                value.perc !== null ? `${numFormat(value.perc, "compact", [1, 1])}%` : "—"
               })`}</p>
             </div>
           </div>
@@ -222,7 +210,7 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
             <p className="text-dim font-medium">
               {flexRender(cell.column.columnDef.header, cell.getContext())}
             </p>
-            <ResultBadge value={cell.getValue()} />
+            <ResultBadge value={value} />
           </div>
         );
 
@@ -353,10 +341,8 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
           );
         })}
         {isLoading && (
-          <div className="flex h-20 w-full">
-            <div className="mx-auto self-center">
-              <Spinner loading={isLoading} />
-            </div>
+          <div className="flex h-20 w-full items-center justify-center">
+            <Spinner loading={isLoading} />
           </div>
         )}
         {!data.length && !isLoading && (

--- a/apps/app/components/Chart/Table/ElectionTable.tsx
+++ b/apps/app/components/Chart/Table/ElectionTable.tsx
@@ -9,6 +9,7 @@ import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack
 import { Tooltip } from "@components/index";
 import BarPerc from "@components/Chart/BarMeter/BarPerc";
 import { ResultBadge } from "@components/Badge/election";
+import { ElectionResult } from "@dashboards/democracy/election-explorer/types";
 
 export interface ElectionTableProps {
   className?: string;
@@ -17,7 +18,7 @@ export interface ElectionTableProps {
   data?: any;
   columns: Array<ColumnDef<any, any>>;
   highlightedRow?: false | number;
-  win?: string;
+  result?: ElectionResult;
   isLoading: boolean;
 }
 
@@ -39,11 +40,11 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
   data = dummyData,
   columns,
   highlightedRow = false,
-  win = "null",
+  result,
   isLoading = false,
 }) => {
   const { t, i18n } = useTranslation(["dashboard-election-explorer", "common"]);
-  console.log(highlightedRow);
+
   const table = useReactTable({
     data,
     columns,
@@ -276,6 +277,9 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
                     >
                       <div className="flex flex-row gap-2">
                         {lookupDesktop(cell.column.columnDef.id, cell)}
+                        {rowIndex === highlightedRow && colIndex === 0 && (
+                          <ResultBadge hidden value={result} />
+                        )}
                       </div>
                     </td>
                   ))}

--- a/apps/app/components/Chart/Table/ElectionTable.tsx
+++ b/apps/app/components/Chart/Table/ElectionTable.tsx
@@ -43,7 +43,7 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
   isLoading = false,
 }) => {
   const { t, i18n } = useTranslation(["dashboard-election-explorer", "common"]);
-
+  console.log(highlightedRow);
   const table = useReactTable({
     data,
     columns,
@@ -298,7 +298,8 @@ const ElectionTable: FunctionComponent<ElectionTableProps> = ({
             <div
               className={clx(
                 "border-outline dark:border-washed-dark flex flex-col space-y-2 border-b p-3 text-sm first:border-t-2 md:hidden",
-                index === 0 && "border-t-2"
+                index === 0 && "border-t-2",
+                index === highlightedRow ? "bg-background dark:bg-background-dark" : "bg-inherit"
               )}
               key={index}
             >

--- a/apps/app/components/Combobox/index.tsx
+++ b/apps/app/components/Combobox/index.tsx
@@ -122,7 +122,7 @@ const ComboBox = <L extends string | number = string, V = string>({
                       {enableFlag ? (
                         <>
                           <ImageWithFallback
-                            className="border-outline dark:border-washed-dark rounded border"
+                            className="border-outline dark:border-outlineHover-dark absolute rounded border"
                             src={`${imageSource}${option.value}.png`}
                             fallback={fallback}
                             width={32}
@@ -131,7 +131,7 @@ const ComboBox = <L extends string | number = string, V = string>({
                           />
                           <span
                             className={clx(
-                              "block truncate",
+                              "relative block truncate pl-10",
                               selected ? "font-medium" : "font-normal"
                             )}
                           >

--- a/apps/app/components/ImageWithFallback/index.tsx
+++ b/apps/app/components/ImageWithFallback/index.tsx
@@ -1,21 +1,29 @@
+import { clx } from "@lib/helpers";
 import Image, { ImageProps } from "next/image";
 import { FunctionComponent, ReactNode, useEffect, useState } from "react";
 
 interface FallbackProps {
   children?: ReactNode;
+  inline?: boolean;
 }
-const Fallback: FunctionComponent<FallbackProps> = ({ children }) => {
+const Fallback: FunctionComponent<FallbackProps> = ({ children, inline = false }) => {
   return (
-    <div className="border-outline dark:border-outlineHover-dark h-5 w-[30px] rounded border bg-white">
+    <div
+      className={clx(
+        "border-outline dark:border-outlineHover-dark h-5 w-[30px] rounded border bg-white",
+        inline ? "mr-2 inline-block" : "absolute"
+      )}
+    >
       {children ?? <div className="text-center font-black leading-4 text-black">?</div>}
     </div>
   );
 };
 interface ImageWithFallbackProps extends ImageProps {
   fallback?: ReactNode;
+  inline?: boolean;
 }
 
-const ImageWithFallback = ({ fallback, alt, src, ...props }: ImageWithFallbackProps) => {
+const ImageWithFallback = ({ fallback, alt, src, inline, ...props }: ImageWithFallbackProps) => {
   const [error, setError] = useState<React.SyntheticEvent<HTMLImageElement, Event> | null>(null);
 
   useEffect(() => {
@@ -23,7 +31,7 @@ const ImageWithFallback = ({ fallback, alt, src, ...props }: ImageWithFallbackPr
   }, [src]);
 
   return error ? (
-    <Fallback>{fallback}</Fallback>
+    <Fallback inline={inline}>{fallback}</Fallback>
   ) : (
     <Image alt={alt} onError={setError} src={src} {...props} />
   );

--- a/apps/app/components/Input/index.tsx
+++ b/apps/app/components/Input/index.tsx
@@ -66,7 +66,7 @@ const Input: FunctionComponent<InputProps> = ({
         max={max}
         className={clx(
           "placeholder:text-dim focus:ring-dim rounded-md outline-none focus:outline-none dark:bg-black",
-          "focus:ring-primary dark:focus:border-ring-dark ",
+          "focus:ring-primary dark:focus:ring-primary-dark",
           icon ? "pl-10" : "",
           validation ? "border-danger border-2" : "border-outline dark:border-washed-dark",
           className

--- a/apps/app/dashboards/democracy/election-explorer/candidates.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/candidates.tsx
@@ -90,11 +90,15 @@ const ElectionCandidatesDashboard: FunctionComponent<ElectionCandidatesProps> = 
   const { data, setData } = useData({
     tab_index: 0, // parlimen = 0; dun = 1
     candidate: params.candidate_name,
+    query: "",
     loading: false,
   });
 
   const navigateToCandidate = (name?: string) => {
-    if (!name) return;
+    if (!name) {
+      setData("candidate", null);
+      return;
+    }
     setData("loading", true);
     setData("candidate", name);
 
@@ -162,7 +166,7 @@ const ElectionCandidatesDashboard: FunctionComponent<ElectionCandidatesProps> = 
                 title={
                   <div className="text-base font-bold">
                     {t("candidate.title")}
-                    <span className="text-primary">{data.candidate}</span>
+                    <span className="text-primary">{params.candidate_name}</span>
                   </div>
                 }
                 current={data.tab_index}

--- a/apps/app/dashboards/democracy/election-explorer/candidates.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/candidates.tsx
@@ -80,6 +80,7 @@ const ElectionCandidatesDashboard: FunctionComponent<ElectionCandidatesProps> = 
               </div>
             }
             subtitle
+            highlighted={params.candidate_name}
             options={selection}
             page={row.index}
           />

--- a/apps/app/dashboards/democracy/election-explorer/candidates.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/candidates.tsx
@@ -71,7 +71,7 @@ const ElectionCandidatesDashboard: FunctionComponent<ElectionCandidatesProps> = 
               },
             ])}
             title={
-              <div className="flex w-full justify-between pr-10">
+              <div className="flex w-full items-start justify-between pr-12">
                 <div className="flex flex-col uppercase md:flex-row md:gap-2">
                   <h5>{area}</h5>
                   <span className="text-dim text-lg font-normal">{state}</span>
@@ -79,6 +79,7 @@ const ElectionCandidatesDashboard: FunctionComponent<ElectionCandidatesProps> = 
                 <ResultBadge value={item.result} />
               </div>
             }
+            subtitle
             options={selection}
             page={row.index}
           />
@@ -90,7 +91,6 @@ const ElectionCandidatesDashboard: FunctionComponent<ElectionCandidatesProps> = 
   const { data, setData } = useData({
     tab_index: 0, // parlimen = 0; dun = 1
     candidate: params.candidate_name,
-    query: "",
     loading: false,
   });
 
@@ -122,11 +122,13 @@ const ElectionCandidatesDashboard: FunctionComponent<ElectionCandidatesProps> = 
           votes: [
             {
               x: "voter_turnout",
-              y: data.votes.voter_turnout_perc,
+              abs: data.votes.voter_turnout,
+              perc: data.votes.voter_turnout_perc,
             },
             {
               x: "rejected_votes",
-              y: data.votes.votes_rejected_perc,
+              abs: data.votes.votes_rejected,
+              perc: data.votes.votes_rejected_perc,
             },
           ],
         };

--- a/apps/app/dashboards/democracy/election-explorer/elections/analysis.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/elections/analysis.tsx
@@ -54,16 +54,14 @@ const ElectionAnalysis: FunctionComponent<ElectionAnalysisProps> = () => {
       <div className="pb-8 lg:grid lg:grid-cols-12 lg:pb-12">
         <div className="lg:col-span-10 lg:col-start-2">
           <h4 className="py-4 text-center">{t("election.section_3")}</h4>
-          <div className="flex flex-row justify-between gap-4 pb-6 sm:flex-row">
-            <div className="flex flex-row items-baseline gap-2 lg:gap-4">
-              <Dropdown
-                anchor="left"
-                width="w-fit"
-                options={FILTER_OPTIONS}
-                selected={FILTER_OPTIONS.find(e => e.value === data.analysis_type.value)}
-                onChange={e => setData("analysis_type", e)}
-              />
-            </div>
+          <div className="flex flex-row flex-wrap justify-between gap-4 pb-6">
+            <Dropdown
+              anchor="left"
+              width="w-fit"
+              options={FILTER_OPTIONS}
+              selected={FILTER_OPTIONS.find(e => e.value === data.analysis_type.value)}
+              onChange={e => setData("analysis_type", e)}
+            />
             <List
               options={[t("election.map"), t("election.table")]}
               icons={[

--- a/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
@@ -2,20 +2,17 @@ import Card from "@components/Card";
 import ElectionTable from "@components/Chart/Table/ElectionTable";
 import ImageWithFallback from "@components/ImageWithFallback";
 import LeftRightCard from "@components/LeftRightCard";
-import Section from "@components/Section";
 import { useData } from "@hooks/useData";
 import { useTranslation } from "@hooks/useTranslation";
 import { get } from "@lib/api";
 import { numFormat, toDate } from "@lib/helpers";
 import { FunctionComponent, useEffect, useMemo } from "react";
 import type { BaseResult, Seat, SeatResult } from "../types";
-
 import { Won } from "@components/Badge/election";
 import BarPerc from "@components/Chart/BarMeter/BarPerc";
 import ComboBox from "@components/Combobox";
 import { SPRIconSolid } from "@components/Icon/agency";
 import { generateSchema } from "@lib/schema/election-explorer";
-import Tooltip from "@components/Tooltip";
 import { toast } from "@components/Toast";
 
 /**
@@ -117,20 +114,28 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
 
             <LeftRightCard
               left={
-                <div className="bg-background dark:bg-washed-dark relative flex h-fit w-full flex-col gap-3 overflow-hidden rounded-t-xl px-3 pb-3 md:overflow-y-auto lg:h-[600px] lg:rounded-l-xl lg:px-6 lg:pb-6">
+                <div
+                  className="bg-background dark:bg-washed-dark relative flex h-fit w-full flex-col gap-3 overflow-hidden 
+                rounded-t-xl px-3 pb-3 md:overflow-y-auto lg:h-[600px] lg:rounded-l-xl lg:px-6 lg:pb-6"
+                >
                   <div className="bg-background dark:bg-washed-dark dark:border-outlineHover-dark sticky top-0 z-10 border-b pb-3 pt-6">
                     <ComboBox
                       placeholder={t("seat.search_seat")}
                       options={SEAT_OPTIONS}
                       selected={data.seat ?? null}
-                      onChange={selected => setData("seat", selected)}
+                      onChange={selected => {
+                        setData("seat", selected);
+                        if (selected) fetchSeatResult(selected.value);
+                      }}
                     />
                   </div>
                   <div className="grid w-full grid-flow-col-dense grid-rows-2 flex-row gap-3 overflow-x-scroll md:flex-col md:overflow-x-clip md:pb-0 lg:flex">
                     {_seats.map((seat: Seat, index: number) => (
                       <Card
                         key={seat.seat}
-                        className="focus:border-primary dark:focus:border-primary-dark hover:border-primary dark:hover:border-primary-dark hover:bg-primary/5 dark:hover:bg-primary-dark/5 flex h-fit w-72 flex-col gap-2 rounded-xl border bg-white p-3 text-sm dark:bg-black xl:w-full"
+                        className="focus:border-primary dark:focus:border-primary-dark hover:border-primary dark:hover:border-primary-dark
+                         hover:bg-primary/5 dark:hover:bg-primary-dark/5 flex h-fit w-72 flex-col gap-2 rounded-xl border bg-white p-3 text-sm
+                          dark:bg-black xl:w-full"
                         onClick={() => fetchSeatResult(seat.seat)}
                       >
                         <div className="flex flex-row justify-between">

--- a/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
@@ -43,7 +43,7 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
     get("/explorer", {
       explorer: "ELECTIONS",
       chart: "full_result",
-      type: "seats",
+      type: "candidates",
       election: election,
       seat: seat,
     })

--- a/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
@@ -236,7 +236,7 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
                         <div className="flex flex-col gap-3 text-sm md:flex-row md:gap-x-6 lg:flex-col xl:flex-row">
                           {data.seat_result.votes.map(
                             (item: { x: string; abs: number; perc: number }) => (
-                              <div className="flex space-x-3 whitespace-nowrap">
+                              <div className="flex space-x-3 whitespace-nowrap" key={item.x}>
                                 <p className="w-28 md:w-fit lg:w-28 xl:w-fit">
                                   {t(`election.${item.x}`)}:
                                 </p>

--- a/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
@@ -156,7 +156,7 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
                         </div>
                         <div className="flex flex-row gap-2">
                           <ImageWithFallback
-                            className="border-outline dark:border-washed-dark items-center self-center rounded border"
+                            className="border-outline dark:border-outlineHover-dark items-center self-center rounded border"
                             src={`/static/images/parties/${seat.party}.png`}
                             width={32}
                             height={18}
@@ -197,14 +197,14 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
                             <p className="text-dim uppercase">{seat_info.state}</p>
                           </div>
                           <div className="flex items-center gap-3">
-                            <p>{seat_info.name}</p>
+                            <p>{t(`${seat_info.name}`)}</p>
                             <p className="text-dim">{seat_info.date}</p>
                           </div>
                         </div>
                       </div>
 
-                      <div className="space-y-2">
-                        <h5>{t("election.election_result")}</h5>
+                      <div className="space-y-3">
+                        <div className="font-bold">{t("election.election_result")}</div>
                         <ElectionTable
                           className="max-h-96 w-full overflow-y-auto"
                           data={data.seat_result.data}
@@ -231,26 +231,26 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
                         />
                       </div>
 
-                      <div className="space-y-2">
-                        <h5>{t("election.voting_statistics")}</h5>
-                        <div className="flex flex-col gap-3 text-sm md:flex-row md:flex-wrap md:gap-x-6">
+                      <div className="space-y-3">
+                        <div className="font-bold">{t("election.voting_statistics")}</div>
+                        <div className="flex flex-col gap-3 text-sm md:flex-row md:gap-x-6 lg:flex-col xl:flex-row">
                           {data.seat_result.votes.map(
                             (item: { x: string; abs: number; perc: number }) => (
-                              <>
-                                <div className="flex space-x-3 whitespace-nowrap">
-                                  <p className="w-[132px] xl:w-fit">{t(`election.${item.x}`)}:</p>
-                                  <div className="flex items-center space-x-3">
-                                    <BarPerc hidden value={item.perc} />
-                                    <p>{`${
-                                      item.abs === 0 ? "0" : numFormat(item.abs, "standard")
-                                    } ${
-                                      item.perc === 0
-                                        ? "(—)"
-                                        : `(${numFormat(item.perc, "compact", [1, 1])}%)`
-                                    }`}</p>
-                                  </div>
+                              <div className="flex space-x-3 whitespace-nowrap">
+                                <p className="w-28 md:w-fit lg:w-28 xl:w-fit">
+                                  {t(`election.${item.x}`)}:
+                                </p>
+                                <div className="flex items-center space-x-3">
+                                  <BarPerc hidden value={item.perc} size={"h-[5px] w-[50px]"} />
+                                  <p>{`${
+                                    item.abs !== null ? numFormat(item.abs, "standard") : "—"
+                                  } ${
+                                    item.perc !== null
+                                      ? `(${numFormat(item.perc, "compact", [1, 1])}%)`
+                                      : "(—)"
+                                  }`}</p>
                                 </div>
-                              </>
+                              </div>
                             )
                           )}
                         </div>

--- a/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
@@ -56,11 +56,13 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
           votes: [
             {
               x: "voter_turnout",
-              y: data.votes.voter_turnout_perc,
+              abs: data.votes.voter_turnout,
+              perc: data.votes.voter_turnout_perc,
             },
             {
               x: "rejected_votes",
-              y: data.votes.votes_rejected_perc,
+              abs: data.votes.votes_rejected,
+              perc: data.votes.votes_rejected_perc,
             },
           ],
         });
@@ -120,7 +122,7 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
                     <ComboBox
                       placeholder={t("seat.search_seat")}
                       options={SEAT_OPTIONS}
-                      selected={data.seat}
+                      selected={data.seat ?? null}
                       onChange={selected => setData("seat", selected)}
                     />
                   </div>
@@ -128,7 +130,7 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
                     {_seats.map((seat: Seat, index: number) => (
                       <Card
                         key={seat.seat}
-                        className="focus:border-primary dark:focus:border-primary-dark hover:border-primary dark:hover:border-primary-dark hover:bg-primary/5 dark:hover:bg-primary-dark/5 flex h-fit w-72 flex-col gap-2 rounded-xl border bg-white p-3 text-sm dark:bg-black lg:w-full"
+                        className="focus:border-primary dark:focus:border-primary-dark hover:border-primary dark:hover:border-primary-dark hover:bg-primary/5 dark:hover:bg-primary-dark/5 flex h-fit w-72 flex-col gap-2 rounded-xl border bg-white p-3 text-sm dark:bg-black xl:w-full"
                         onClick={() => fetchSeatResult(seat.seat)}
                       >
                         <div className="flex flex-row justify-between">
@@ -179,7 +181,7 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
                 </div>
               }
               right={
-                <div className="h-full w-full space-y-8 overflow-y-auto rounded-b-xl bg-white p-6 dark:bg-black md:h-[600px] md:p-10 lg:rounded-r-xl lg:p-8">
+                <div className="h-full w-full space-y-8 overflow-y-auto rounded-b-xl bg-white p-6 dark:bg-black md:h-[600px] lg:rounded-r-xl lg:p-8">
                   {data.seat_result.data.length > 0 ? (
                     <>
                       <div className="flex items-center gap-4">
@@ -226,21 +228,26 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
 
                       <div className="space-y-2">
                         <h5>{t("election.voting_statistics")}</h5>
-                        <div className="item-center flex w-full flex-row gap-4 lg:gap-8">
-                          {data.seat_result.votes.map((item: { x: string; y: number }) => (
-                            <BarPerc
-                              size="h-2.5 w-full"
-                              key={item.x}
-                              label={
-                                <div className="flex items-center gap-1">
-                                  {t(`election.${item.x}`)}
-                                  <Tooltip tip={t(`tooltip.${item.x}`)} />
+                        <div className="flex flex-col gap-3 text-sm md:flex-row md:flex-wrap md:gap-x-6">
+                          {data.seat_result.votes.map(
+                            (item: { x: string; abs: number; perc: number }) => (
+                              <>
+                                <div className="flex space-x-3 whitespace-nowrap">
+                                  <p className="w-[132px] xl:w-fit">{t(`election.${item.x}`)}:</p>
+                                  <div className="flex items-center space-x-3">
+                                    <BarPerc hidden value={item.perc} />
+                                    <p>{`${
+                                      item.abs === 0 ? "0" : numFormat(item.abs, "standard")
+                                    } ${
+                                      item.perc === 0
+                                        ? "(—)"
+                                        : `(${numFormat(item.perc, "compact", [1, 1])}%)`
+                                    }`}</p>
+                                  </div>
                                 </div>
-                              }
-                              value={item.y}
-                              className="w-full space-y-1 text-sm"
-                            />
-                          ))}
+                              </>
+                            )
+                          )}
                         </div>
                       </div>
                     </>

--- a/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
@@ -227,7 +227,7 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
                           ])}
                           isLoading={data.seat_loading}
                           highlightedRow={0}
-                          win="win"
+                          result="won"
                         />
                       </div>
 

--- a/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/elections/ballot-seat.tsx
@@ -107,7 +107,7 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
   }, [data.seat]);
 
   return (
-    <Section>
+    <>
       <div className="lg:grid lg:grid-cols-12">
         <div className="space-y-12 lg:col-span-10 lg:col-start-2">
           <div className="space-y-6">
@@ -115,7 +115,7 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
 
             <LeftRightCard
               left={
-                <div className="bg-background dark:bg-washed-dark relative flex h-fit w-full flex-col gap-3 overflow-hidden rounded-t-xl px-3 pb-3 md:h-[600px] md:overflow-y-auto lg:rounded-l-xl lg:px-6 lg:pb-6">
+                <div className="bg-background dark:bg-washed-dark relative flex h-fit w-full flex-col gap-3 overflow-hidden rounded-t-xl px-3 pb-3 md:overflow-y-auto lg:h-[600px] lg:rounded-l-xl lg:px-6 lg:pb-6">
                   <div className="bg-background dark:bg-washed-dark dark:border-outlineHover-dark sticky top-0 z-10 border-b pb-3 pt-6">
                     <ComboBox
                       placeholder={t("seat.search_seat")}
@@ -128,7 +128,7 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
                     {_seats.map((seat: Seat, index: number) => (
                       <Card
                         key={seat.seat}
-                        className="dark:border-outlineHover-dark focus:border-primary dark:focus:border-primary-dark hover:border-primary dark:hover:border-primary-dark hover:bg-primary/5 dark:hover:bg-primary-dark/5 flex h-fit flex-col gap-2 rounded-xl border bg-white p-3 text-sm dark:bg-black"
+                        className="focus:border-primary dark:focus:border-primary-dark hover:border-primary dark:hover:border-primary-dark hover:bg-primary/5 dark:hover:bg-primary-dark/5 flex h-fit w-72 flex-col gap-2 rounded-xl border bg-white p-3 text-sm dark:bg-black lg:w-full"
                         onClick={() => fetchSeatResult(seat.seat)}
                       >
                         <div className="flex flex-row justify-between">
@@ -179,7 +179,7 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
                 </div>
               }
               right={
-                <div className="h-full w-full space-y-8 rounded-b-xl bg-white p-3 dark:bg-black md:h-[600px] md:p-10 lg:rounded-r-xl">
+                <div className="h-full w-full space-y-8 overflow-y-auto rounded-b-xl bg-white p-6 dark:bg-black md:h-[600px] md:p-10 lg:rounded-r-xl lg:p-8">
                   {data.seat_result.data.length > 0 ? (
                     <>
                       <div className="flex items-center gap-4">
@@ -253,7 +253,7 @@ const BallotSeat: FunctionComponent<BallotSeatProps> = ({ seats, election }) => 
           </div>
         </div>
       </div>
-    </Section>
+    </>
   );
 };
 

--- a/apps/app/dashboards/democracy/election-explorer/elections/index.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/elections/index.tsx
@@ -130,7 +130,7 @@ const ElectionExplorer: FunctionComponent<ElectionExplorerProps> = ({ seats, par
           {/* Explore any election from Merdeka to the present! */}
           <Section>
             <h4 className="text-center">{t("election.section_1")}</h4>
-            <div className={clx("fixed right-0 top-16 z-10 lg:hidden")}>
+            <div className={clx("fixed right-0 top-16 z-20 lg:hidden")}>
               <Modal
                 trigger={open => (
                   <Button
@@ -213,7 +213,7 @@ const ElectionExplorer: FunctionComponent<ElectionExplorerProps> = ({ seats, par
 
             <div
               ref={divRef}
-              className="sticky top-16 z-10 mt-6 hidden items-center justify-center gap-2 transition-all duration-200 ease-in lg:flex lg:pl-2"
+              className="sticky top-16 z-20 mt-6 hidden items-center justify-center gap-2 transition-all duration-200 ease-in lg:flex lg:pl-2"
             >
               <div className="border-outline dark:border-washed-dark max-w-fit rounded-full border bg-white p-1 dark:bg-black">
                 <List
@@ -362,10 +362,10 @@ const ElectionExplorer: FunctionComponent<ElectionExplorerProps> = ({ seats, par
                 </Tabs.Panel>
               ))}
             </Tabs>
-          </Section>
 
-          {/* View the full ballot for a specific seat */}
-          <BallotSeat seats={seats} election={data.election} />
+            {/* View the full ballot for a specific seat */}
+            <BallotSeat seats={seats} election={data.election} />
+          </Section>
 
           {/* Election analysis */}
           <ElectionAnalysis />

--- a/apps/app/dashboards/democracy/election-explorer/elections/index.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/elections/index.tsx
@@ -103,7 +103,7 @@ const ElectionExplorer: FunctionComponent<ElectionExplorerProps> = ({ seats, par
   const ELECTION_OPTIONS: Array<OptionType> = Array(16)
     .fill(null)
     .map((n, index: number) => ({
-      label: (data.list_index === 0 ? t("GE") : t("SE")) + `-${String(index).padStart(2, "0")}`,
+      label: t((data.list_index === 0 ? "GE" : "SE") + `-${String(index).padStart(2, "0")}`),
       value: (data.list_index === 0 ? "GE" : "SE") + `-${String(index).padStart(2, "0")}`,
     }))
     .reverse();
@@ -295,10 +295,7 @@ const ElectionExplorer: FunctionComponent<ElectionExplorerProps> = ({ seats, par
                               {
                                 key: "seats",
                                 id: "seats",
-                                header:
-                                  table.length > 0
-                                    ? `${t("seats_won")} / ${table[0].seats.total}`
-                                    : t("seats_won"),
+                                header: t("seats_won"),
                               },
                               { key: "votes", id: "votes", header: t("votes_won") },
                             ])}
@@ -329,7 +326,7 @@ const ElectionExplorer: FunctionComponent<ElectionExplorerProps> = ({ seats, par
                                     <div className="bg-dim h-4 w-4 rounded-md"></div>
                                   ) : (
                                     <ImageWithFallback
-                                      className="border-outline dark:border-washed-dark rounded border"
+                                      className="border-outline dark:border-outlineHover-dark rounded border"
                                       src={`/static/images/parties/${label}.png`}
                                       width={32}
                                       height={18}

--- a/apps/app/dashboards/democracy/election-explorer/layout.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/layout.tsx
@@ -68,6 +68,7 @@ const ElectionLayout: FunctionComponent<ElectionLayoutProps> = ({ children }) =>
             )}
             key={nav.url}
             href={nav.url}
+            scrollTop={false}
           >
             {nav.icon}
             {nav.name}

--- a/apps/app/dashboards/democracy/election-explorer/layout.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/layout.tsx
@@ -57,13 +57,13 @@ const ElectionLayout: FunctionComponent<ElectionLayoutProps> = ({ children }) =>
       />
 
       {/* Navigations */}
-      <div className="flex flex-row overflow-x-auto border-b md:justify-center">
+      <div className="border-outline dark:border-b-washed-dark flex flex-row overflow-x-auto border-b md:justify-center">
         {election_navs.map(nav => (
           <At
             className={clx(
-              "flex flex-row items-center gap-1 px-4 py-4 text-sm font-medium transition hover:cursor-pointer lg:text-base",
+              "flex flex-row items-center gap-1 px-4 py-4 text-sm font-medium transition lg:text-base",
               pathname.startsWith(nav.url)
-                ? "border-primary dark:border-primary-dark border-b-2 text-black"
+                ? "border-primary dark:border-primary-dark border-b-2 text-black dark:text-white"
                 : "text-dim"
             )}
             key={nav.url}

--- a/apps/app/dashboards/democracy/election-explorer/parties.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/parties.tsx
@@ -16,6 +16,7 @@ import { FunctionComponent } from "react";
 import type { ElectionResource, Party, PartyResult } from "./types";
 import ElectionLayout from "./layout";
 import { toast } from "@components/Toast";
+import { toDate } from "@lib/helpers";
 
 /**
  * Election Explorer Dashboard - Political Parties Tab
@@ -42,7 +43,6 @@ const ElectionPartiesDashboard: FunctionComponent<ElectionPartiesProps> = ({
     tab_index: 0, // parlimen = 0; dun = 1
     party: params.party_name,
     state: params.state,
-
     loading: false,
   });
 
@@ -93,11 +93,14 @@ const ElectionPartiesDashboard: FunctionComponent<ElectionPartiesProps> = ({
             ])}
             title={
               <div className="flex flex-row gap-2 uppercase">
-                <h5>{item.election_name}</h5>
+                <h5>{t(item.election_name)}</h5>
+                <h5 className="text-dim font-normal">
+                  {toDate(item.date, "dd MMM yyyy", i18n.language)}
+                </h5>
               </div>
             }
             options={selection}
-            // highlightedRow={data.full_results.findIndex((r: Result) => r.name === data.candidate)}
+            highlighted={params.party_name}
             page={row.index}
           />
         );
@@ -138,9 +141,13 @@ const ElectionPartiesDashboard: FunctionComponent<ElectionPartiesProps> = ({
     })
       .then(({ data }: { data: PartyResult }) => {
         return {
-          data: data.sort(
-            (a: PartyResult[number], b: PartyResult[number]) => b.votes.abs - a.votes.abs
-          ),
+          data: data.sort((a: PartyResult[number], b: PartyResult[number]) => {
+            if (a.seats.won === b.seats.won) {
+              return b.votes.abs - a.votes.abs;
+            } else {
+              return b.seats.won - a.seats.won;
+            }
+          }),
         };
       })
       .catch(e => {
@@ -173,11 +180,12 @@ const ElectionPartiesDashboard: FunctionComponent<ElectionPartiesProps> = ({
                   <Trans>
                     <span className="text-lg font-normal leading-9">
                       <ImageWithFallback
-                        className="border-outline dark:border-washed-dark mr-2 inline-flex items-center rounded border"
+                        className="border-outline dark:border-outlineHover-dark mr-2 inline-block items-center rounded border"
                         src={`/static/images/parties/${params.party_name}.png`}
                         width={32}
                         height={18}
                         alt={t(`${params.party_name}`)}
+                        inline
                       />
                       {t("party.title", {
                         party: `$t(dashboard-election-explorer:${params.party_name})`,

--- a/apps/app/dashboards/democracy/election-explorer/parties.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/parties.tsx
@@ -111,7 +111,10 @@ const ElectionPartiesDashboard: FunctionComponent<ElectionPartiesProps> = ({
   }));
 
   const navigateToParty = (name?: string, state?: string) => {
-    if (!name) return;
+    if (!name) {
+      setData("party", null);
+      return;
+    }
     setData("loading", true);
     setData("party", name);
 
@@ -171,13 +174,13 @@ const ElectionPartiesDashboard: FunctionComponent<ElectionPartiesProps> = ({
                     <span className="text-lg font-normal leading-9">
                       <ImageWithFallback
                         className="border-outline dark:border-washed-dark mr-2 inline-flex items-center rounded border"
-                        src={`/static/images/parties/${data.party}.png`}
+                        src={`/static/images/parties/${params.party_name}.png`}
                         width={32}
                         height={18}
-                        alt={t(`${data.party}`)}
+                        alt={t(`${params.party_name}`)}
                       />
                       {t("party.title", {
-                        party: `$t(dashboard-election-explorer:${data.party})`,
+                        party: `$t(dashboard-election-explorer:${params.party_name})`,
                       })}
                       <StateDropdown
                         currentState={data.state}
@@ -203,7 +206,7 @@ const ElectionPartiesDashboard: FunctionComponent<ElectionPartiesProps> = ({
                     empty={
                       <Trans>
                         {t("party.no_data", {
-                          party: `$t(dashboard-election-explorer:${data.party})`,
+                          party: `$t(dashboard-election-explorer:${params.party_name})`,
                           context: "parliament",
                         })}
                       </Trans>
@@ -218,7 +221,7 @@ const ElectionPartiesDashboard: FunctionComponent<ElectionPartiesProps> = ({
                     empty={
                       <Trans>
                         {t("party.no_data", {
-                          party: `$t(dashboard-election-explorer:${data.party})`,
+                          party: `$t(dashboard-election-explorer:${params.party_name})`,
                           state: CountryAndStates[data.state],
                           context: data.state === "mys" ? "dun_mys" : "dun",
                         })}

--- a/apps/app/dashboards/democracy/election-explorer/seats.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/seats.tsx
@@ -40,7 +40,7 @@ const ElectionSeatsDashboard: FunctionComponent<ElectionSeatsProps> = ({
   const { push } = useRouter();
 
   const { data, setData } = useData({
-    seat: params?.seat_name,
+    seat: params.seat_name,
     loading: false,
   });
 
@@ -50,7 +50,10 @@ const ElectionSeatsDashboard: FunctionComponent<ElectionSeatsProps> = ({
   }));
 
   const navigateToSeat = (name?: string) => {
-    if (!name) return;
+    if (!name) {
+      setData("seat", null);
+      return;
+    }
     setData("loading", true);
     setData("seat", name);
 
@@ -60,7 +63,7 @@ const ElectionSeatsDashboard: FunctionComponent<ElectionSeatsProps> = ({
     }).then(() => setData("loading", false));
   };
 
-  const [area, state] = data.seat.split(",");
+  const [area, state] = params.seat_name.split(",");
 
   const fetchResult = async (election: string, seat: string) => {
     return get("/explorer", {
@@ -156,10 +159,8 @@ const ElectionSeatsDashboard: FunctionComponent<ElectionSeatsProps> = ({
                   <ComboBox
                     placeholder={t("seat.search_seat")}
                     options={SEAT_OPTIONS}
-                    selected={
-                      data.seat ? SEAT_OPTIONS.find(e => e.value === data.seat.value) : null
-                    }
-                    onChange={e => navigateToSeat(e?.value)}
+                    selected={data.seat ? SEAT_OPTIONS.find(e => e.value === data.seat) : null}
+                    onChange={selected => navigateToSeat(selected?.value)}
                     enableType={true}
                   />
                 </div>

--- a/apps/app/dashboards/democracy/election-explorer/seats.tsx
+++ b/apps/app/dashboards/democracy/election-explorer/seats.tsx
@@ -63,13 +63,11 @@ const ElectionSeatsDashboard: FunctionComponent<ElectionSeatsProps> = ({
     }).then(() => setData("loading", false));
   };
 
-  const [area, state] = params.seat_name.split(",");
-
   const fetchResult = async (election: string, seat: string) => {
     return get("/explorer", {
       explorer: "ELECTIONS",
       chart: "full_result",
-      type: "seats",
+      type: "candidates",
       election,
       seat,
     })
@@ -79,11 +77,13 @@ const ElectionSeatsDashboard: FunctionComponent<ElectionSeatsProps> = ({
           votes: [
             {
               x: "voter_turnout",
-              y: data.votes.voter_turnout_perc,
+              abs: data.votes.voter_turnout,
+              perc: data.votes.voter_turnout_perc,
             },
             {
               x: "rejected_votes",
-              y: data.votes.votes_rejected_perc,
+              abs: data.votes.votes_rejected,
+              perc: data.votes.votes_rejected_perc,
             },
           ],
         };
@@ -134,11 +134,12 @@ const ElectionSeatsDashboard: FunctionComponent<ElectionSeatsProps> = ({
               },
             ])}
             title={
-              <div className="block align-baseline uppercase md:flex md:flex-row md:items-center md:gap-2">
+              <div className="uppercase md:flex md:flex-row md:items-center md:gap-2">
                 <h5 className="text">{area}</h5>
-                <p className="text-dim font-normal">{state}</p>
+                <h5 className="text-dim font-normal">{state}</h5>
               </div>
             }
+            subtitle
             options={elections}
             page={row.index}
           />
@@ -167,9 +168,9 @@ const ElectionSeatsDashboard: FunctionComponent<ElectionSeatsProps> = ({
               </div>
               <ElectionTable
                 title={
-                  <div className="flex flex-col uppercase md:flex-row md:gap-2">
-                    <h5>{area}</h5>
-                    <span className="text-dim font-normal">{state}</span>
+                  <div className="pb-6 font-bold">
+                    {t("seat.title")}
+                    <span className="text-primary">{params.seat_name}</span>
                   </div>
                 }
                 data={elections}

--- a/apps/app/dashboards/democracy/election-explorer/types.ts
+++ b/apps/app/dashboards/democracy/election-explorer/types.ts
@@ -9,10 +9,6 @@ export type Candidate = {
   party: string;
   votes: Record<"abs" | "perc", number>;
   result: ElectionResult;
-  voter_turnout: number;
-  voter_turnout_perc: number;
-  voter_rejected: number;
-  voter_rejected_perc: number;
 };
 
 export type Party = {

--- a/apps/app/pages/dashboard/election-explorer/elections/[...election].tsx
+++ b/apps/app/pages/dashboard/election-explorer/elections/[...election].tsx
@@ -70,7 +70,11 @@ export const getStaticProps: GetStaticProps = withi18n(
           params: { election, state: state ?? "mys" },
           seats: seats.data,
           table: table.data.sort((a: Party, b: Party) => {
-            return b.seats.won - a.seats.won;
+            if (a.seats.won === b.seats.won) {
+              return b.votes.perc - a.votes.perc;
+            } else {
+              return b.seats.won - a.seats.won;
+            }
           }),
         },
       };

--- a/apps/app/pages/dashboard/election-explorer/elections/index.tsx
+++ b/apps/app/pages/dashboard/election-explorer/elections/index.tsx
@@ -5,6 +5,7 @@ import Metadata from "@components/Metadata";
 import { useTranslation } from "@hooks/useTranslation";
 import ElectionExplorerDashboard from "@dashboards/democracy/election-explorer/elections";
 import { withi18n } from "@lib/decorators";
+import { Party } from "@dashboards/democracy/election-explorer/types";
 
 const ElectionExplorerIndex: Page = ({
   seats,
@@ -52,7 +53,13 @@ export const getStaticProps: GetStaticProps = withi18n("dashboard-election-explo
         },
         params: { election, state },
         seats: seats.data,
-        table: table.data,
+        table: table.data.sort((a: Party, b: Party) => {
+          if (a.seats.won === b.seats.won) {
+            return b.votes.perc - a.votes.perc;
+          } else {
+            return b.seats.won - a.seats.won;
+          }
+        }),
       },
     };
   } catch (error: any) {

--- a/apps/app/styles/globals.css
+++ b/apps/app/styles/globals.css
@@ -21,15 +21,15 @@
   }
 
   h3 {
-    @apply font-header text-2xl font-bold leading-[32px] dark:text-white;
+    @apply font-header text-2xl font-bold dark:text-white;
   }
 
   h4 {
-    @apply font-header text-xl font-bold leading-[28px] dark:text-white;
+    @apply font-header text-xl font-bold dark:text-white;
   }
 
   h5 {
-    @apply text-base font-bold tracking-normal dark:text-white lg:text-lg;
+    @apply text-lg font-bold dark:text-white;
   }
 
   h6 {


### PR DESCRIPTION
### Changes
- disable scroll to top when navigating to routes
- standardise Ballot Seat card width on mobile 
- hide overflow of voting stats
- increase z-index of filters
- sort result by seats and votes
- add help cursor when hover 
- clear search box on X click
- combine 2 sections in `Election` for filter bar to hover over both
- integrate new Voting Stats design
- fetchSeatResult on search
- highlight row according to candidate/name/elected
- refactor to only use em dash when absolute value or percent is `null`
- change election name i18n
- change party full result title, seats table title