### PR TITLE
feat: show plural form for views and downloads

### DIFF
--- a/apps/app/components/Hero/index.tsx
+++ b/apps/app/components/Hero/index.tsx
@@ -100,7 +100,9 @@ const Hero: FunctionComponent<HeroProps> = ({
                   {result?.all_time_view && (
                     <p className="text-dim flex gap-2 text-sm">
                       <EyeIcon className="w-4.5 h-4.5 self-center" />
-                      {numFormat(result.all_time_view, "standard")} {t("common:common.views")}
+                      {`${numFormat(result.all_time_view, "standard")} ${t("common:common.views", {
+                        count: result.all_time_view,
+                      })}`}
                     </p>
                   )}
                 </div>

--- a/apps/app/dashboards/index.tsx
+++ b/apps/app/dashboards/index.tsx
@@ -286,7 +286,9 @@ const Ranking = ({ ranks }: RankingProps) => {
                   {t(`dashboards.${item.name}.description`)}
                 </p>
                 <p className="text-dim transition-transform group-hover:translate-y-6">
-                  {`${numFormat(item.views, "compact")} ${t("common:common.views")}`}
+                  {`${numFormat(item.views, "compact")} ${t("common:common.views", {
+                    count: item.views,
+                  })}`}
                 </p>
                 <p className="text-primary dark:text-primary-dark absolute -bottom-6 transition-transform group-hover:-translate-y-6">
                   {t("common:components.click_to_explore")}

--- a/apps/app/data-catalogue/show.tsx
+++ b/apps/app/data-catalogue/show.tsx
@@ -414,11 +414,13 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
 
           <p className="text-dim mt-6 flex justify-end gap-2 text-sm">
             <span>
-              {numFormat(result?.all_time_view ?? 0, "compact", 1)} {t("common:common.views")}
+              {`${numFormat(result?.all_time_view ?? 0, "compact", 1)} ${t("common:common.views", {
+                count: result?.all_time_view ?? 0,
+              })}`}
             </span>
             <span>&middot;</span>
             <span>
-              {numFormat(
+              {`${numFormat(
                 sum([
                   result?.download_csv,
                   result?.download_parquet,
@@ -427,8 +429,15 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
                 ]) ?? 0,
                 "compact",
                 1
-              )}{" "}
-              {t("common:common.downloads")}
+              )} ${t("common:common.downloads", {
+                count:
+                  sum([
+                    result?.download_csv,
+                    result?.download_parquet,
+                    result?.download_png,
+                    result?.download_svg,
+                  ]) ?? 0,
+              })}`}
             </span>
           </p>
         </Section>

--- a/apps/app/pages/index.tsx
+++ b/apps/app/pages/index.tsx
@@ -269,7 +269,9 @@ const Ranking = ({ ranks }: RankingProps) => {
                   {item[`name_${lang as "en" | "bm"}`]}
                 </p>
                 <p className="text-dim transition-transform group-hover:translate-y-6">
-                  {numFormat(item.count, "compact")} {t("common:common.views")}
+                  {`${numFormat(item.count, "compact")} ${t("common:common.views", {
+                    count: item.count,
+                  })}`}
                 </p>
                 <p className="text-primary dark:text-primary-dark absolute -bottom-6 transition-transform group-hover:-translate-y-6">
                   {t("common:components.click_to_explore")}


### PR DESCRIPTION
## Changes made
1. i18n meta has been updated as follow:
```json
"views_one": "view",
"views_other": "views",
"downloads_one": "download",
"downloads_other": "downloads",
```
2. FE has been updated by passing the value to the translation context for plural form.

## Considerations
i18n could handle the numFormat() responsibility, since it also provides Intl API functionalities? 
https://www.i18next.com/translation-function/formatting 