### PR TITLE
Style/car popularity

### DIFF
--- a/apps/app/components/Chart/Timeseries/index.tsx
+++ b/apps/app/components/Chart/Timeseries/index.tsx
@@ -352,6 +352,7 @@ const Timeseries: FunctionComponent<TimeseriesProps> = ({
             },
           },
           ticks: {
+            precision: Array.isArray(precision) ? precision[1] : precision,
             stepSize: stepSize,
             padding: 6,
             callback: (value: string | number) => {

--- a/apps/app/dashboards/transportation/car-popularity/index.tsx
+++ b/apps/app/dashboards/transportation/car-popularity/index.tsx
@@ -272,7 +272,6 @@ const CarPopularity: FunctionComponent<CarPopularityProps> = ({
                     isLoading={query.loading}
                     precision={0}
                     suggestedMaxY={2}
-                    className="h-96 pt-2"
                     title={
                       <div className="flex flex-col gap-3">
                         <p className="text-lg font-bold">

--- a/apps/app/dashboards/transportation/car-popularity/index.tsx
+++ b/apps/app/dashboards/transportation/car-popularity/index.tsx
@@ -268,53 +268,48 @@ const CarPopularity: FunctionComponent<CarPopularityProps> = ({
             <div className="w-full">
               <WindowProvider>
                 {data.x?.length > 0 ? (
-                  query.loading ? (
-                    <div className="flex h-96 items-center justify-center">
-                      <Spinner loading={query.loading} />
-                    </div>
-                  ) : (
-                    <Timeseries
-                      stepSize={1}
-                      suggestedMaxY={2}
-                      className="h-96 pt-2"
-                      title={
-                        <div className="flex flex-col gap-3">
-                          <p className="text-lg font-bold">
-                            <span className="capitalize">
-                              {t("timeseries_car_description", {
-                                car: data.params.model,
-                                maker: data.params.maker,
-                              })}
-                            </span>
-                            <span>{t("timeseries_title")}</span>
-                          </p>
-                          <p className="text-dim text-sm">
-                            <span>{t("timeseries_description")}</span>
-                          </p>
-                        </div>
-                      }
-                      interval={"year"}
-                      data={{
-                        labels: data.x,
-                        datasets: [
-                          {
-                            type: "line",
-                            data: data.y,
-                            label: t("label"),
-                            backgroundColor: AKSARA_COLOR.PRIMARY_H,
-                            borderColor: AKSARA_COLOR.PRIMARY,
-                            borderWidth:
-                              breakpoint <= BREAKPOINTS.MD
-                                ? 0.75
-                                : breakpoint <= BREAKPOINTS.LG
-                                ? 1.0
-                                : 1.5,
-                            fill: true,
-                          },
-                        ],
-                      }}
-                    />
-                  )
+                  <Timeseries
+                    isLoading={query.loading}
+                    precision={0}
+                    suggestedMaxY={2}
+                    className="h-96 pt-2"
+                    title={
+                      <div className="flex flex-col gap-3">
+                        <p className="text-lg font-bold">
+                          <span className="capitalize">
+                            {t("timeseries_car_description", {
+                              car: data.params.model,
+                              maker: data.params.maker,
+                            })}
+                          </span>
+                          <span>{t("timeseries_title")}</span>
+                        </p>
+                        <p className="text-dim text-sm">
+                          <span>{t("timeseries_description")}</span>
+                        </p>
+                      </div>
+                    }
+                    interval={"year"}
+                    data={{
+                      labels: data.x,
+                      datasets: [
+                        {
+                          type: "line",
+                          data: data.y,
+                          label: t("label"),
+                          backgroundColor: AKSARA_COLOR.PRIMARY_H,
+                          borderColor: AKSARA_COLOR.PRIMARY,
+                          borderWidth:
+                            breakpoint <= BREAKPOINTS.MD
+                              ? 0.75
+                              : breakpoint <= BREAKPOINTS.LG
+                              ? 1.0
+                              : 1.5,
+                          fill: true,
+                        },
+                      ],
+                    }}
+                  />
                 ) : (
                   <div className="relative hidden h-96 w-full items-center justify-center lg:flex">
                     <Timeseries

--- a/apps/app/dashboards/transportation/car-popularity/index.tsx
+++ b/apps/app/dashboards/transportation/car-popularity/index.tsx
@@ -269,6 +269,7 @@ const CarPopularity: FunctionComponent<CarPopularityProps> = ({
               <WindowProvider>
                 {data.x?.length > 0 ? (
                   <Timeseries
+                    className="h-[300px]"
                     isLoading={query.loading}
                     precision={0}
                     suggestedMaxY={2}

--- a/apps/app/dashboards/transportation/car-popularity/index.tsx
+++ b/apps/app/dashboards/transportation/car-popularity/index.tsx
@@ -149,7 +149,7 @@ const CarPopularity: FunctionComponent<CarPopularityProps> = ({
               />
             </div>
 
-            <div className="flex flex-col gap-3 lg:grid lg:grid-cols-12">
+            <div className="flex flex-col gap-12 lg:grid lg:grid-cols-12">
               <table className="lg:col-span-4 lg:col-start-3">
                 <thead className="border-b-2">
                   <tr>


### PR DESCRIPTION
## Changes made
1. Fixed gap between the two tables - made bigger.
2. Used timeseries component loading state, instead of importing new loading state spinner.
3. Timeseries y-axis labels were too close to each other when there are a lot of data points, this was due to using stepSize=1, refactored to use precision=0. 

## TODOs
Timeseries chart seems to not resize responsively when the width of browser changes. I believe @leneherng knows a fix to this? 