### PR TITLE
Feat/data catalogue api query

### DIFF
--- a/apps/app/components/CodeBlock/index.tsx
+++ b/apps/app/components/CodeBlock/index.tsx
@@ -21,10 +21,10 @@ const LANGUAGE_OPTIONS = [
     label: "JavaScript",
     value: "javascript",
   },
-  {
-    label: "Kotlin",
-    value: "kotlin",
-  },
+  // {
+  //   label: "Kotlin",
+  //   value: "kotlin",
+  // },
 ] as const;
 
 export type Language = (typeof LANGUAGE_OPTIONS)[number]["value"];

--- a/apps/app/data-catalogue/partials/code.tsx
+++ b/apps/app/data-catalogue/partials/code.tsx
@@ -56,7 +56,77 @@ print(df)`;
     }
   }, [type]);
 
-  return <CodeBlock event={{ url }}>{template}</CodeBlock>;
+  return <CodeBlock event={{ url }}>{{ python: template }}</CodeBlock>;
 };
+
+const generalQuery: APIQuery[] = [
+  { param: "id", value: "<catalogue_id>", comment: "ID of data catalogue" },
+  {
+    param: "filter",
+    value: "<value>@<column>",
+    comment: "filter(s) of the response",
+  },
+  { param: "limit", value: "<int>", comment: "response limit (length of data)" },
+  { param: "sort", value: "<column>@<order>", comment: "order of response (asc/desc)" },
+  {
+    param: "exclude",
+    value: "<column1>,<column2>",
+    comment: "columns to exclude (comma-separated)",
+  },
+  { param: "include", value: "<column1>,<column2>", comment: "alternative to exclude" },
+  { param: "start", value: "<date>", comment: "data start date range (YYY-MM-DD)" },
+  { param: "end", value: "<date>", comment: "data end date range (YYY-MM-DD)" },
+];
+
+interface SampelCodeProps {
+  url: string;
+  queries?: APIQuery[];
+}
+
+export type APIQuery = {
+  param: string;
+  value: string;
+  comment?: string;
+};
+
+const SampleCode: FunctionComponent<SampelCodeProps> = ({ url, queries = [] }) => {
+  const { t } = useTranslation(["catalogue", "common"]);
+
+  const generateQueryString = (queries: APIQuery[], commentSymbol: string) => {
+    return `{\n${queries
+      .map(q => `\t"${q.param}": "${q.value}" ${q.comment ? `${commentSymbol} ${q.comment}` : ""}`)
+      .join("\n")}\n}`;
+  };
+
+  if (queries.length === 0) {
+    queries = generalQuery;
+  }
+
+  const children = {
+    javascript: `
+import fetch from "node-fetch";
+
+const ENDPOINT = "https://api.data.gov.my/data-catalogue";
+const params = new URLSearchParams(${generateQueryString(queries, "//")});
+const response = fetch()
+    .then((response) => response.json())
+    .then((json) => console.log(json))
+    .catch((err) => console.log(err));
+    `,
+    python: `import requests
+import pprint
+
+ENDPOINT = "https://api.data.gov.my/data-catalogue" 
+
+query_params = ${generateQueryString(queries, "#")}
+
+response_json = requests.get(url=ENDPOINT, params=query_params).json()
+pprint.pprint(response_json)`,
+  };
+
+  return <CodeBlock event={{ url }}>{children}</CodeBlock>;
+};
+
+export { SampleCode };
 
 export default CatalogueCode;

--- a/apps/app/data-catalogue/show.tsx
+++ b/apps/app/data-catalogue/show.tsx
@@ -23,7 +23,8 @@ import Tooltip from "@components/Tooltip";
 import { useFilter } from "@hooks/useFilter";
 import dynamic from "next/dynamic";
 import Image from "next/image";
-import CatalogueCode from "./partials/code";
+import CatalogueCode, { APIQuery } from "./partials/code";
+import { SampleCode } from "./partials/code";
 import { useAnalytics } from "@hooks/useAnalytics";
 import sum from "lodash/sum";
 import { WindowProvider } from "@hooks/useWindow";
@@ -103,6 +104,7 @@ interface CatalogueShowProps {
   translations: {
     [key: string]: string;
   };
+  queries?: APIQuery[];
 }
 
 const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
@@ -114,6 +116,7 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
   metadata,
   urls,
   translations,
+  queries,
 }) => {
   const { t, i18n } = useTranslation(["catalogue", "common"]);
   const [show, setShow] = useState<OptionType>(options[0]);
@@ -646,9 +649,18 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
           </div>
         </Section>
 
-        {/* Code */}
+        {/* Dataset Source Code */}
         <Section title={t("code")} description={t("code_desc")} className="mx-auto w-full py-12">
           <CatalogueCode type={dataset.type} url={urls?.parquet || urls[Object.keys(urls)[0]]} />
+        </Section>
+
+        {/* API Request Code */}
+        <Section
+          title={t("sample_query.section_title")}
+          description={t("sample_query.description")}
+          className="mx-auto w-full py-12"
+        >
+          <SampleCode queries={queries} url={urls?.parquet || urls[Object.keys(urls)[0]]} />
         </Section>
       </Container>
     </div>

--- a/apps/app/pages/data-catalogue/[id].tsx
+++ b/apps/app/pages/data-catalogue/[id].tsx
@@ -20,6 +20,7 @@ const CatalogueShow: Page = ({
   metadata,
   urls,
   translations,
+  queries,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const { t } = useTranslation(["catalogue", "common"]);
 
@@ -57,6 +58,7 @@ const CatalogueShow: Page = ({
         metadata={metadata}
         urls={urls}
         translations={translations}
+        queries={queries}
       />
     </AnalyticsProvider>
   );
@@ -147,6 +149,7 @@ export const getServerSideProps: GetServerSideProps = withi18n(
         },
         urls: data.downloads ?? {},
         translations: data.translations ?? {},
+        queries: data.queries ?? [],
       },
     };
   }


### PR DESCRIPTION
## Changes made
**CodeBlock component**
- Originally only support Python, now supports both Python and JS.
- Support rendering different content based on the language by changing `children` prop type from `string` to `Partial<Record<Language, string>>`, where Language is the union type of valid programming languages, e.g. `python | javascript`.
    - e.g. children `"print("success")"` -> `{python: "print("success")", javascript: "console.log("success");"}`

**apps/app/data-catalogue/partials/code.tsx** 
- update CatalogueCode `template` to wrap around` {python: template}` after the above changes.
- Create new SampleCode component for the new Sample API request section code block.

**Others**
- Support dynamic query parameters based on data catalogue BE response. Provide general/default queries if it is empty. 
