### PR TITLE
Update/simplify catalogue query

### DIFF
--- a/apps/app/components/CodeBlock/index.tsx
+++ b/apps/app/components/CodeBlock/index.tsx
@@ -8,6 +8,7 @@ import swift from "highlight.js/lib/languages/swift";
 import dart from "highlight.js/lib/languages/dart";
 import kotlin from "highlight.js/lib/languages/kotlin";
 import java from "highlight.js/lib/languages/java";
+import html_xml from "highlight.js/lib/languages/xml";
 import { GithubThemes } from "./theme";
 import { clx, copyClipboard } from "@lib/helpers";
 import { useTranslation } from "@hooks/useTranslation";
@@ -62,6 +63,7 @@ const CodeBlock: FunctionComponent<CodeBlockProps> = ({ children, hidden, event 
   hljs.registerLanguage("dart", dart);
   hljs.registerLanguage("kotlin", kotlin);
   hljs.registerLanguage("java", java);
+  hljs.registerLanguage("html", html_xml);
 
   const languageOptions = LANGUAGE_OPTIONS.filter(({ value }) => {
     return Object.keys(children).includes(value);

--- a/apps/app/components/CodeBlock/index.tsx
+++ b/apps/app/components/CodeBlock/index.tsx
@@ -4,7 +4,10 @@ import { FunctionComponent, useEffect, useMemo, useState } from "react";
 import hljs from "highlight.js/lib/core";
 import python from "highlight.js/lib/languages/python";
 import javascript from "highlight.js/lib/languages/javascript";
-import html_xml from "highlight.js/lib/languages/xml";
+import swift from "highlight.js/lib/languages/swift";
+import dart from "highlight.js/lib/languages/dart";
+import kotlin from "highlight.js/lib/languages/kotlin";
+import java from "highlight.js/lib/languages/java";
 import { GithubThemes } from "./theme";
 import { clx, copyClipboard } from "@lib/helpers";
 import { useTranslation } from "@hooks/useTranslation";
@@ -24,6 +27,22 @@ const LANGUAGE_OPTIONS = [
     label: "HTML",
     value: "html",
   },
+  {
+    label: "Swift",
+    value: "swift",
+  },
+  {
+    label: "Dart",
+    value: "dart",
+  },
+  {
+    label: "Kotlin",
+    value: "kotlin",
+  },
+  {
+    label: "Java",
+    value: "java",
+  },
 ] as const;
 
 export type Language = (typeof LANGUAGE_OPTIONS)[number]["value"];
@@ -39,7 +58,10 @@ const CodeBlock: FunctionComponent<CodeBlockProps> = ({ children, hidden, event 
   const { theme = "light" } = useTheme();
   hljs.registerLanguage("python", python);
   hljs.registerLanguage("javascript", javascript);
-  hljs.registerLanguage("html", html_xml);
+  hljs.registerLanguage("swift", swift);
+  hljs.registerLanguage("dart", dart);
+  hljs.registerLanguage("kotlin", kotlin);
+  hljs.registerLanguage("java", java);
 
   const languageOptions = LANGUAGE_OPTIONS.filter(({ value }) => {
     return Object.keys(children).includes(value);

--- a/apps/app/data-catalogue/partials/code.tsx
+++ b/apps/app/data-catalogue/partials/code.tsx
@@ -72,15 +72,19 @@ const SampleCode: FunctionComponent<SampelCodeProps> = ({
   const sampleUrl = `https://api.data.gov.my/data-catalogue?id=${catalogueId}&limit=3`;
 
   const children: Partial<Record<Language, string>> = {
-    javascript: `
-import fetch from "node-fetch";
+    javascript: `var requestOptions = {
+  method: "GET",
+  redirect: "follow",
+};
 
-const url = "${sampleUrl}";
+fetch(
+  "${sampleUrl}",
+  requestOptions
+)
+  .then((response) => response.json())
+  .then((result) => console.log(result))
+  .catch((error) => console.log("error", error));
 
-const response = fetch(url)
-    .then((response) => response.json())
-    .then((json) => console.log(json))
-    .catch((err) => console.log(err));
     `,
     python: `import requests
 import pprint
@@ -89,15 +93,22 @@ url = "${sampleUrl}"
 
 response_json = requests.get(url=url).json()
 pprint.pprint(response_json)`,
-    dart: `var request = http.Request('GET', Uri.parse("${sampleUrl}"));
+    dart: `import 'package:http/http.dart' as http;
 
-http.StreamedResponse response = await request.send();
-
-if (response.statusCode == 200) {
-  print(await response.stream.bytesToString());
-}
-else {
-  print(response.reasonPhrase);
+void main() async {
+  var request = http.Request('GET', Uri.parse('${sampleUrl}'));
+  
+  request.followRedirects = false;
+  
+  http.StreamedResponse response = await request.send();
+  
+  if (response.statusCode == 200) {
+    print(await response.stream.bytesToString());
+  }
+  else {
+    print(response.reasonPhrase);
+  }
+  
 }
     `,
     swift: `import Foundation
@@ -105,8 +116,7 @@ else {
 import FoundationNetworking
 #endif
 
-var request = URLRequest(url: URL(string: "${sampleUrl}")!,
-  timeoutInterval: Double.infinity)
+var request = URLRequest(url: URL(string: "${sampleUrl}")!,timeoutInterval: Double.infinity)
 request.httpMethod = "GET"
 
 let task = URLSession.shared.dataTask(with: request) { data, response, error in 
@@ -120,6 +130,7 @@ let task = URLSession.shared.dataTask(with: request) { data, response, error in
 
 task.resume()
 dispatchMain()
+    
     `,
     kotlin: `import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
@@ -138,15 +149,24 @@ val response = client.newCall(request).execute()
 
 println(response.body!!.string())
     `,
-    java: `OkHttpClient client = new OkHttpClient().newBuilder()
-  .build();
-MediaType mediaType = MediaType.parse("text/plain");
-RequestBody body = RequestBody.create(mediaType, "");
-Request request = new Request.Builder()
-  .url("https://api.data.gov.my/data-catalogue?id=<id>&limit=3")
-  .method("GET", body)
-  .build();
-Response response = client.newCall(request).execute();`,
+    java: `import java.io.*;
+import okhttp3.*;
+public class Main {
+  public static void main(String []args) throws IOException{
+    OkHttpClient client = new OkHttpClient().newBuilder()
+      .followRedirects(false)
+      .build();
+    MediaType mediaType = MediaType.parse("text/plain");
+    RequestBody body = RequestBody.create(mediaType, "");
+    Request request = new Request.Builder()
+      .url("${sampleUrl}")
+      .method("GET", body)
+      .build();
+    Response response = client.newCall(request).execute();
+    System.out.println(response.body().string());
+  }
+}
+    `,
   };
 
   return <CodeBlock event={{ url }}>{children}</CodeBlock>;

--- a/apps/app/data-catalogue/show.tsx
+++ b/apps/app/data-catalogue/show.tsx
@@ -23,7 +23,7 @@ import Tooltip from "@components/Tooltip";
 import { useFilter } from "@hooks/useFilter";
 import dynamic from "next/dynamic";
 import Image from "next/image";
-import CatalogueCode, { APIQuery } from "./partials/code";
+import CatalogueCode from "./partials/code";
 import { SampleCode } from "./partials/code";
 import { useAnalytics } from "@hooks/useAnalytics";
 import sum from "lodash/sum";
@@ -105,7 +105,7 @@ interface CatalogueShowProps {
   translations: {
     [key: string]: string;
   };
-  queries?: APIQuery[];
+  catalogueId?: string;
 }
 
 const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
@@ -117,7 +117,7 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
   metadata,
   urls,
   translations,
-  queries,
+  catalogueId,
 }) => {
   const { t, i18n } = useTranslation(["catalogue", "common"]);
   const [show, setShow] = useState<OptionType>(options[0]);
@@ -674,7 +674,7 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
           description={t("sample_query.description")}
           className="mx-auto w-full py-12"
         >
-          <SampleCode queries={queries} url={urls?.parquet || urls[Object.keys(urls)[0]]} />
+          <SampleCode catalogueId={catalogueId} url={urls?.parquet || urls[Object.keys(urls)[0]]} />
         </Section>
       </Container>
     </div>

--- a/apps/app/data-catalogue/show.tsx
+++ b/apps/app/data-catalogue/show.tsx
@@ -294,6 +294,36 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
     }
   };
 
+  const sampleDescription = (
+    <>
+      {t("sample_query.desc1")}
+      <At
+        external={true}
+        className="link-dim text-base underline"
+        href={
+          i18n.language == "en-GB"
+            ? "https://developer.data.gov.my/data-catalogue/request-query"
+            : "https://developer.data.gov.my/ms/data-catalogue/request-query"
+        }
+      >
+        {t("sample_query.link1")}
+      </At>
+      <span>{`. ${t("sample_query.desc2")}`}</span>
+      <At
+        external={true}
+        className="link-dim text-base underline"
+        href={
+          i18n.language == "en-GB"
+            ? `https://developer.data.gov.my/data-catalogue/example-requests?id=${catalogueId}`
+            : `https://developer.data.gov.my/ms/data-catalogue/example-requests?id=${catalogueId}`
+        }
+      >
+        {t("sample_query.link2")}
+      </At>
+      .
+    </>
+  );
+
   return (
     <div>
       <Container className="mx-auto w-full pt-6 md:max-w-screen-md lg:max-w-screen-lg">
@@ -671,7 +701,7 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
         {/* API Request Code */}
         <Section
           title={t("sample_query.section_title")}
-          description={t("sample_query.description")}
+          description={sampleDescription}
           className="mx-auto w-full py-12"
         >
           <SampleCode catalogueId={catalogueId} url={urls?.parquet || urls[Object.keys(urls)[0]]} />

--- a/apps/app/pages/data-catalogue/[id].tsx
+++ b/apps/app/pages/data-catalogue/[id].tsx
@@ -20,7 +20,7 @@ const CatalogueShow: Page = ({
   metadata,
   urls,
   translations,
-  queries,
+  catalogueId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const { t } = useTranslation(["catalogue", "common"]);
 
@@ -58,7 +58,7 @@ const CatalogueShow: Page = ({
         metadata={metadata}
         urls={urls}
         translations={translations}
-        queries={queries}
+        catalogueId={catalogueId}
       />
     </AnalyticsProvider>
   );
@@ -149,7 +149,7 @@ export const getServerSideProps: GetServerSideProps = withi18n(
         },
         urls: data.downloads ?? {},
         translations: data.translations ?? {},
-        queries: data.queries ?? [],
+        catalogueId: params?.id,
       },
     };
   }


### PR DESCRIPTION
## Changes made
1. Registered new languages to highlight.js for syntax highlighting, e.g Swift, Dart, Kotlin, Java.
2. Simplify query parameter processing - only use catalogue ID instead of a list of queries to build the query (`?id=<id>&limit=3` is now the standard format) 
3. Updated the description to redirect users to full documentation page for more information. 

NOTE: the sample code is directly taken from Postman code examples for the different languages

## TODOs
1. Catalogue ID information is passed along to developer.data.gov.my, so users are able to live test the query themselves. This should be completed on the docs site once the design is finalised