### PR TITLE
Feat/name popularity privacy

### DIFF
--- a/apps/app/components/Chart/Bar/index.tsx
+++ b/apps/app/components/Chart/Bar/index.tsx
@@ -207,7 +207,7 @@ const Bar: FunctionComponent<BarProps> = ({
           callback: function (value: string | number) {
             return displayLabel(
               isVertical
-                ? display(value as number, "compact", 1)
+                ? display(value as number, "compact", precision)
                 : this.getLabelForValue(value as number).concat(unitX ?? "")
             );
           },

--- a/apps/app/dashboards/demography/name-popularity/index.tsx
+++ b/apps/app/dashboards/demography/name-popularity/index.tsx
@@ -495,7 +495,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                               {item.total.toLocaleString("en-US")}
                             </td>
                             <td className="border-b-outline dark:border-washed-dark border-b p-2">
-                              {item.total === 0 ? item.max : item.max.toString().concat("s")}
+                              {item.max ? item.max.toString().concat("s") : "N/A"}
                             </td>
                           </tr>
                         )

--- a/apps/app/dashboards/demography/name-popularity/index.tsx
+++ b/apps/app/dashboards/demography/name-popularity/index.tsx
@@ -2,7 +2,16 @@ import AgencyBadge from "@components/Badge/agency";
 import Card from "@components/Card";
 import Chips from "@components/Chips";
 import { JPNIcon } from "@components/Icon/agency";
-import { Button, Container, Dropdown, Hero, Input, Radio, Section } from "@components/index";
+import {
+  Button,
+  Container,
+  Dropdown,
+  Hero,
+  Input,
+  Radio,
+  Section,
+  Tooltip,
+} from "@components/index";
 import Toggle from "@components/Toggle";
 import Spinner from "@components/Spinner";
 import { OptionType } from "@components/types";
@@ -40,7 +49,10 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
       label: t(`ethnicity.${ethnicityDropdown.at(0)}`),
       value: ethnicityDropdown.at(0),
     },
-    selectedYear: { label: `${yearDropdown.at(-1)}`, value: `${yearDropdown.at(-1)}` },
+    selectedYear: {
+      label: t("year_format", { year: yearDropdown.at(-1) }),
+      value: `${yearDropdown.at(-1)}`,
+    },
   });
 
   const { data: searchData, setData: setSearchData } = useData({
@@ -65,7 +77,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
   });
 
   const yearOptions: OptionType[] = yearDropdown.map(val => ({
-    label: val.toString(),
+    label: t("year_format", { year: val }),
     value: val.toString(),
   }));
 
@@ -292,13 +304,15 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                     .map((item: { name_first: string; sex: string; count: number }, i: number) => (
                       <tr
                         key={i}
-                        className={"dark:border-washed-dark border-b".concat(
-                          i < 3 ? " bg-background dark:bg-background-dark" : ""
+                        className={clx(
+                          "dark:border-washed-dark border-b",
+                          i < 3 ? "bg-background dark:bg-background-dark" : ""
                         )}
                       >
                         <td
-                          className={"px-1 py-2 text-center text-sm font-medium".concat(
-                            i < 3 ? " text-primary dark:text-primary-dark" : ""
+                          className={clx(
+                            "px-1 py-2 text-center text-sm font-medium",
+                            i < 3 ? "text-primary dark:text-primary-dark" : ""
                           )}
                         >
                           {i + 1}
@@ -333,13 +347,15 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                     .map((item: { name_first: string; sex: string; count: number }, i: number) => (
                       <tr
                         key={i}
-                        className={"dark:border-washed-dark border-b".concat(
-                          i < 3 ? " bg-background dark:bg-background-dark" : ""
+                        className={clx(
+                          "dark:border-washed-dark border-b",
+                          i < 3 ? "bg-background dark:bg-background-dark" : ""
                         )}
                       >
                         <td
-                          className={"px-1 py-2 text-center text-sm font-medium".concat(
-                            i < 3 ? " text-primary dark:text-primary-dark" : ""
+                          className={clx(
+                            "px-1 py-2 text-center text-sm font-medium",
+                            i < 3 ? "text-primary dark:text-primary-dark" : ""
                           )}
                         >
                           {i + 1}
@@ -375,10 +391,11 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                 </div>
                 <Input
                   type="search"
-                  className={"dark:focus:border-primary-dark rounded-md border".concat(
+                  className={clx(
+                    "dark:focus:border-primary-dark rounded-md border",
                     searchData.validation
-                      ? " border-danger dark:border-danger border-2"
-                      : " border-outline border-2 dark:border-zinc-800 dark:bg-zinc-900"
+                      ? "border-danger dark:border-danger border-2"
+                      : "border-outline border-2 dark:border-zinc-800 dark:bg-zinc-900"
                   )}
                   placeholder={
                     searchData.type.value === "last"
@@ -466,7 +483,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                       }
                       data={{
                         labels: searchData.data.decade
-                          ? searchData.data.decade.map((x: string) => x.toString().concat("s"))
+                          ? searchData.data.decade.map((x: string) => t("year_format", { year: x }))
                           : placeholderData.decade,
                         datasets: [
                           {
@@ -513,12 +530,13 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                   <Input
                     type="search"
                     disabled={compareData.names.length > 9}
-                    className={"dark:focus:border-primary-dark rounded-md border".concat(
+                    className={clx(
+                      "dark:focus:border-primary-dark rounded-md border",
                       compareData.validation
-                        ? " border-danger dark:border-danger border-2"
+                        ? "border-danger dark:border-danger border-2"
                         : compareData.names.length > 9
-                        ? " border-outline bg-outline text-dim border opacity-30 dark:border-black dark:bg-black"
-                        : " border-outline border-2 dark:border-zinc-800 dark:bg-zinc-900"
+                        ? "border-outline bg-outline text-dim border opacity-30 dark:border-black dark:bg-black"
+                        : "border-outline border-2 dark:border-zinc-800 dark:bg-zinc-900"
                     )}
                     placeholder={
                       compareData.type.value === "compare_last"
@@ -612,15 +630,18 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                         ) => (
                           <tr
                             key={item.name}
-                            className={(i < Math.min(3, compareData.data.length - 1)
-                              ? "bg-background dark:border-washed-dark dark:bg-washed-dark/50"
-                              : ""
-                            ).concat(" md:text-md text-sm")}
+                            className={clx(
+                              i < Math.min(3, compareData.data.length - 1)
+                                ? "bg-background dark:border-washed-dark dark:bg-washed-dark/50"
+                                : "",
+                              "md:text-md text-sm"
+                            )}
                           >
                             <td
-                              className={"border-b-outline dark:border-washed-dark border-b p-2".concat(
+                              className={clx(
+                                "border-b-outline dark:border-washed-dark border-b p-2",
                                 i < Math.min(3, compareData.data.length - 1)
-                                  ? " text-primary dark:text-primary-dark"
+                                  ? "text-primary dark:text-primary-dark"
                                   : ""
                               )}
                             >

--- a/apps/app/dashboards/demography/name-popularity/index.tsx
+++ b/apps/app/dashboards/demography/name-popularity/index.tsx
@@ -37,7 +37,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
 
   const { data: tableData, setData: setTableData } = useData({
     selectedEthnicity: {
-      label: t(ethnicityDropdown.at(0) as string),
+      label: t(`ethnicity.${ethnicityDropdown.at(0)}`),
       value: ethnicityDropdown.at(0),
     },
     selectedYear: { label: `${yearDropdown.at(-1)}`, value: `${yearDropdown.at(-1)}` },
@@ -70,7 +70,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
   }));
 
   const ethnicityOptions: OptionType[] = ethnicityDropdown.map(ethnicity => ({
-    label: t(ethnicity),
+    label: t(`ethnicity.${ethnicity}`),
     value: ethnicity,
   }));
   const { theme } = useTheme();
@@ -254,7 +254,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
         <Section>
           <div className="space-y-6">
             <div className="flex flex-col place-content-center place-items-center gap-3 sm:flex-row">
-              <h4 className="text-center">{t("Most popular")}</h4>
+              <h4 className="text-center">{t("section1_title1")}</h4>
               <Dropdown
                 width="w-fit"
                 selected={tableData.selectedEthnicity}
@@ -263,7 +263,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                 }}
                 options={ethnicityOptions}
               />
-              <h4 className="text-center">{t("baby names in")}</h4>
+              <h4 className="text-center">{t("section1_title2")}</h4>
               <Dropdown
                 width="w-fit"
                 selected={tableData.selectedYear}
@@ -357,7 +357,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
             </div>
           </div>
         </Section>
-        <Section title={t("section1_title")}>
+        <Section title={t("section2_title")}>
           <div className="grid grid-cols-3 gap-8">
             <div className="col-span-full lg:col-span-1">
               <Card className="border-outline bg-background dark:border-washed-dark dark:bg-washed-dark/50 shadow-button flex flex-col	justify-start gap-6 rounded-xl border p-6">
@@ -437,7 +437,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                       </div>
                       {renderPlaceholderBar(
                         <LockClosedIcon className="h-4 w-4" />,
-                        t("To preserve privacy, timeseries data for this name is not displayed.")
+                        t("privacy_prompt")
                       )}
                     </div>
                   ) : (
@@ -493,7 +493,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
           </div>
         </Section>
 
-        <Section title={t("section2_title")}>
+        <Section title={t("section3_title")}>
           <div className="grid grid-cols-3 gap-8">
             <div className="col-span-full lg:col-span-1">
               <Card className="border-outline bg-background dark:border-washed-dark dark:bg-washed-dark/50 shadow-button flex flex-col	justify-start gap-6 rounded-xl border p-6">

--- a/apps/app/dashboards/demography/name-popularity/index.tsx
+++ b/apps/app/dashboards/demography/name-popularity/index.tsx
@@ -16,6 +16,7 @@ import { useTheme } from "next-themes";
 import dynamic from "next/dynamic";
 import { FunctionComponent, useContext } from "react";
 import { toast } from "@components/Toast";
+import { clx } from "@lib/helpers";
 /**
  * Name Popularity Dashboard
  * @overview Status: Live
@@ -398,99 +399,98 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
               </Card>
             </div>
 
-            {!showPlaceholder && !compareData.data ? (
-              <></>
-            ) : (
-              <div className="col-span-full flex min-h-[460px] flex-col gap-3 lg:col-span-2">
-                <div className="flex flex-col gap-2 md:flex-row md:justify-between">
-                  <p className="text-lg font-bold">
-                    <span>{t("compare_title")}</span>
-                  </p>
-                  <Toggle
-                    enabled={false}
-                    onStateChanged={checked => setCompareData("order", checked)}
-                    label={t("compare_toggle")}
-                  />
-                </div>
-
-                <table className="w-full table-fixed border-collapse">
-                  <thead>
-                    <tr className="md:text-md border-b-outline dark:border-washed-dark max-w-full border-b-2 text-left text-sm [&>*]:p-2">
-                      <th className="w-5 md:w-[50px]">#</th>
-                      <th>
-                        {compareData.params.type === "last" ? t("last_name") : t("first_name")}
-                      </th>
-                      <th>{t("table_total")}</th>
-                      <th>{t("table_most_popular")}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {compareData.data ? (
-                      compareData.data
-                        .sort((a: { total: number }, b: { total: number }) =>
-                          a.total == 0
-                            ? Number.MIN_VALUE
-                            : compareData.order
-                            ? b.total - a.total
-                            : a.total - b.total
-                        )
-                        .map(
-                          (
-                            item: { name: string; total: number; max: string; min: string },
-                            i: number
-                          ) => (
-                            <tr
-                              key={item.name}
-                              className={(i < Math.min(3, compareData.data.length - 1)
-                                ? "bg-background dark:border-washed-dark dark:bg-washed-dark/50"
-                                : ""
-                              ).concat(" md:text-md text-sm")}
-                            >
-                              <td
-                                className={"border-b-outline dark:border-washed-dark border-b p-2".concat(
-                                  i < Math.min(3, compareData.data.length - 1)
-                                    ? " text-primary dark:text-primary-dark"
-                                    : ""
-                                )}
-                              >
-                                {i + 1}
-                              </td>
-                              <td className="border-b-outline dark:border-washed-dark truncate border-b p-2 capitalize">
-                                {`${item.name} `.concat(
-                                  i < Math.min(3, compareData.data.length - 1) ? emojiMap[i] : ""
-                                )}
-                              </td>
-                              <td className="border-b-outline dark:border-washed-dark border-b p-2">
-                                {item.total.toLocaleString("en-US")}
-                              </td>
-                              <td className="border-b-outline dark:border-washed-dark border-b p-2">
-                                {item.total === 0 ? item.max : item.max.toString().concat("s")}
-                              </td>
-                            </tr>
-                          )
-                        )
-                    ) : compareData.isLoading ? (
-                      <tr>
-                        <td colSpan={5}>
-                          <div className="grid place-items-center py-3">
-                            <Spinner loading={compareData.isLoading} />
-                          </div>
-                        </td>
-                      </tr>
-                    ) : (
-                      <tr>
-                        <td colSpan={5}>
-                          <Card className="border-outline bg-outline dark:border-washed-dark dark:bg-washed-dark my-3 hidden w-fit flex-row items-center gap-2 rounded-md border px-3 py-1.5 md:mx-auto lg:flex">
-                            <MagnifyingGlassIcon className=" h-4 w-4" />
-                            <p>{t("compare_prompt")}</p>
-                          </Card>
-                        </td>
-                      </tr>
-                    )}
-                  </tbody>
-                </table>
+            <div
+              className={clx(
+                "col-span-full flex min-h-[460px] flex-col gap-3 lg:col-span-2",
+                compareData.data ?? "hidden lg:flex"
+              )}
+            >
+              <div className="flex flex-col gap-2 md:flex-row md:justify-between">
+                <p className="text-lg font-bold">
+                  <span>{t("compare_title")}</span>
+                </p>
+                <Toggle
+                  enabled={false}
+                  onStateChanged={checked => setCompareData("order", checked)}
+                  label={t("compare_toggle")}
+                />
               </div>
-            )}
+
+              <table className="w-full table-fixed border-collapse">
+                <thead>
+                  <tr className="md:text-md border-b-outline dark:border-washed-dark max-w-full border-b-2 text-left text-sm [&>*]:p-2">
+                    <th className="w-5 md:w-[50px]">#</th>
+                    <th>{compareData.params.type === "last" ? t("last_name") : t("first_name")}</th>
+                    <th>{t("table_total")}</th>
+                    <th>{t("table_most_popular")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {compareData.data ? (
+                    compareData.data
+                      .sort((a: { total: number }, b: { total: number }) =>
+                        a.total == 0
+                          ? Number.MIN_VALUE
+                          : compareData.order
+                          ? b.total - a.total
+                          : a.total - b.total
+                      )
+                      .map(
+                        (
+                          item: { name: string; total: number; max: string; min: string },
+                          i: number
+                        ) => (
+                          <tr
+                            key={item.name}
+                            className={(i < Math.min(3, compareData.data.length - 1)
+                              ? "bg-background dark:border-washed-dark dark:bg-washed-dark/50"
+                              : ""
+                            ).concat(" md:text-md text-sm")}
+                          >
+                            <td
+                              className={"border-b-outline dark:border-washed-dark border-b p-2".concat(
+                                i < Math.min(3, compareData.data.length - 1)
+                                  ? " text-primary dark:text-primary-dark"
+                                  : ""
+                              )}
+                            >
+                              {i + 1}
+                            </td>
+                            <td className="border-b-outline dark:border-washed-dark truncate border-b p-2 capitalize">
+                              {`${item.name} `.concat(
+                                i < Math.min(3, compareData.data.length - 1) ? emojiMap[i] : ""
+                              )}
+                            </td>
+                            <td className="border-b-outline dark:border-washed-dark border-b p-2">
+                              {item.total.toLocaleString("en-US")}
+                            </td>
+                            <td className="border-b-outline dark:border-washed-dark border-b p-2">
+                              {item.total === 0 ? item.max : item.max.toString().concat("s")}
+                            </td>
+                          </tr>
+                        )
+                      )
+                  ) : compareData.isLoading ? (
+                    <tr>
+                      <td colSpan={5}>
+                        <div className="grid place-items-center py-3">
+                          <Spinner loading={compareData.isLoading} />
+                        </div>
+                      </td>
+                    </tr>
+                  ) : (
+                    <tr>
+                      <td colSpan={5}>
+                        <Card className="border-outline bg-outline dark:border-washed-dark dark:bg-washed-dark my-3 hidden w-fit flex-row items-center gap-2 rounded-md border px-3 py-1.5 md:mx-auto lg:flex">
+                          <MagnifyingGlassIcon className=" h-4 w-4" />
+                          <p>{t("compare_prompt")}</p>
+                        </Card>
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
           </div>
         </Section>
       </Container>

--- a/apps/app/dashboards/demography/name-popularity/index.tsx
+++ b/apps/app/dashboards/demography/name-popularity/index.tsx
@@ -635,7 +635,24 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                               {item.total.toLocaleString("en-US")}
                             </td>
                             <td className="border-b-outline dark:border-washed-dark border-b p-2">
-                              {item.max ? item.max.toString().concat("s") : "N/A"}
+                              {item.max ? (
+                                t("year_format", { year: item.max })
+                              ) : item.total === 0 ? (
+                                "N/A"
+                              ) : (
+                                <div className="flex">
+                                  <Tooltip tip={t("privacy_prompt2")} className="left-1/3">
+                                    {open => (
+                                      <div
+                                        className="cursor-help whitespace-nowrap underline decoration-dashed [text-underline-position:from-font]"
+                                        onClick={open}
+                                      >
+                                        <LockClosedIcon className="h-4 w-4" />
+                                      </div>
+                                    )}
+                                  </Tooltip>
+                                </div>
+                              )}
                             </td>
                           </tr>
                         )

--- a/apps/app/dashboards/demography/name-popularity/index.tsx
+++ b/apps/app/dashboards/demography/name-popularity/index.tsx
@@ -2,7 +2,7 @@ import AgencyBadge from "@components/Badge/agency";
 import Card from "@components/Card";
 import Chips from "@components/Chips";
 import { JPNIcon } from "@components/Icon/agency";
-import { Button, Container, Hero, Input, Radio, Section } from "@components/index";
+import { Button, Container, Dropdown, Hero, Input, Radio, Section } from "@components/index";
 import Toggle from "@components/Toggle";
 import Spinner from "@components/Spinner";
 import { OptionType } from "@components/types";
@@ -24,12 +24,24 @@ const Bar = dynamic(() => import("@components/Chart/Bar"), { ssr: false });
 
 interface NamePopularityDashboardProps {
   top_names: Record<string, any>;
+  yearDropdown: number[];
+  ethnicityDropdown: string[];
 }
 
 const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> = ({
   top_names,
+  yearDropdown,
+  ethnicityDropdown,
 }) => {
   const { t } = useTranslation(["dashboard-name-popularity", "common"]);
+
+  const { data: tableData, setData: setTableData } = useData({
+    selectedEthnicity: {
+      label: t(ethnicityDropdown.at(0) as string),
+      value: ethnicityDropdown.at(0),
+    },
+    selectedYear: { label: `${yearDropdown.at(-1)}`, value: `${yearDropdown.at(-1)}` },
+  });
 
   const { data: searchData, setData: setSearchData } = useData({
     type: { label: t("first_name"), value: "first" },
@@ -52,6 +64,15 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
     loading: false,
   });
 
+  const yearOptions: OptionType[] = yearDropdown.map(val => ({
+    label: val.toString(),
+    value: val.toString(),
+  }));
+
+  const ethnicityOptions: OptionType[] = ethnicityDropdown.map(ethnicity => ({
+    label: t(ethnicity),
+    value: ethnicity,
+  }));
   const { theme } = useTheme();
 
   const filterTypes: Array<OptionType> = [
@@ -230,6 +251,112 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
         }
       />
       <Container className="min-h-screen">
+        <Section>
+          <div className="space-y-6">
+            <div className="flex flex-col place-content-center place-items-center gap-3 sm:flex-row">
+              <h4 className="text-center">{t("Most popular")}</h4>
+              <Dropdown
+                width="w-fit"
+                selected={tableData.selectedEthnicity}
+                onChange={e => {
+                  setTableData("selectedEthnicity", e);
+                }}
+                options={ethnicityOptions}
+              />
+              <h4 className="text-center">{t("baby names in")}</h4>
+              <Dropdown
+                width="w-fit"
+                selected={tableData.selectedYear}
+                onChange={e => {
+                  setTableData("selectedYear", e);
+                }}
+                options={yearOptions}
+              />
+            </div>
+            <div className="flex flex-col gap-12 lg:grid lg:grid-cols-12">
+              <table className="lg:col-span-4 lg:col-start-3">
+                <thead className="dark:border-washed-dark border-b-2">
+                  <tr>
+                    <th className="px-1 py-2 text-center text-sm font-medium">#</th>
+                    <th className="px-1 py-2 text-start text-sm font-medium">
+                      {t("column_male_name")}
+                    </th>
+                    <th className="px-1 py-2 text-end text-sm font-medium">{t("column_count")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {top_names[tableData.selectedYear.value][tableData.selectedEthnicity.value]
+                    .filter(({ sex }: { sex: string }) => {
+                      return sex === "male";
+                    })
+                    .map((item: { name_first: string; sex: string; count: number }, i: number) => (
+                      <tr
+                        key={i}
+                        className={"dark:border-washed-dark border-b".concat(
+                          i < 3 ? " bg-background dark:bg-background-dark" : ""
+                        )}
+                      >
+                        <td
+                          className={"px-1 py-2 text-center text-sm font-medium".concat(
+                            i < 3 ? " text-primary dark:text-primary-dark" : ""
+                          )}
+                        >
+                          {i + 1}
+                        </td>
+                        <td className="w-1/2 px-1 py-2 text-start text-sm font-medium capitalize">
+                          {`${item.name_first}`}
+                        </td>
+
+                        <td className="px-1 py-2 text-end text-sm font-medium">
+                          {item.count.toLocaleString()}
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+
+              <table className="lg:col-span-4 lg:col-start-7">
+                <thead className="dark:border-washed-dark border-b-2">
+                  <tr>
+                    <th className="px-1 py-2 text-center text-sm font-medium">#</th>
+                    <th className="px-1 py-2 text-start text-sm font-medium">
+                      {t("column_female_name")}
+                    </th>
+                    <th className="px-1 py-2 text-end text-sm font-medium">{t("column_count")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {top_names[tableData.selectedYear.value][tableData.selectedEthnicity.value]
+                    .filter(({ sex }: { sex: string }) => {
+                      return sex === "female";
+                    })
+                    .map((item: { name_first: string; sex: string; count: number }, i: number) => (
+                      <tr
+                        key={i}
+                        className={"dark:border-washed-dark border-b".concat(
+                          i < 3 ? " bg-background dark:bg-background-dark" : ""
+                        )}
+                      >
+                        <td
+                          className={"px-1 py-2 text-center text-sm font-medium".concat(
+                            i < 3 ? " text-primary dark:text-primary-dark" : ""
+                          )}
+                        >
+                          {i + 1}
+                        </td>
+                        <td className="w-1/2 px-1 py-2 text-start text-sm font-medium capitalize">
+                          {`${item.name_first}`}
+                        </td>
+                        <td className="px-1 py-2 text-end text-sm font-medium">
+                          {item.count.toLocaleString()}
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Section>
         <Section title={t("section1_title")}>
           <div className="grid grid-cols-3 gap-8">
             <div className="col-span-full lg:col-span-1">

--- a/apps/app/dashboards/demography/name-popularity/index.tsx
+++ b/apps/app/dashboards/demography/name-popularity/index.tsx
@@ -179,8 +179,17 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
     count: [10004, 13409, 30904, 43434, 50694, 75443, 70530, 78667, 62537, 15519],
   };
 
-  const renderPlaceholderBar = (icon: ReactNode, prompt_key: string) => (
-    <div className="relative hidden h-[460px] w-full items-center justify-center lg:flex">
+  const renderPlaceholderBar = (
+    icon: ReactNode,
+    prompt_key: string,
+    alwaysShow: boolean = true
+  ) => (
+    <div
+      className={clx(
+        "relative h-[460px] w-full items-center justify-center",
+        alwaysShow ? "flex" : "hidden lg:flex"
+      )}
+    >
       <Bar
         className="absolute top-0 h-[460px] w-full opacity-10"
         precision={0}
@@ -347,7 +356,11 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                   )}
                 </div>
               ) : (
-                renderPlaceholderBar(<MagnifyingGlassIcon className="h-4 w-4" />, "search_prompt")
+                renderPlaceholderBar(
+                  <MagnifyingGlassIcon className="h-4 w-4" />,
+                  "search_prompt",
+                  false
+                )
               )}
             </div>
           </div>

--- a/apps/app/dashboards/demography/name-popularity/index.tsx
+++ b/apps/app/dashboards/demography/name-popularity/index.tsx
@@ -9,12 +9,10 @@ import { OptionType } from "@components/types";
 import { MagnifyingGlassIcon, LockClosedIcon } from "@heroicons/react/20/solid";
 import { useData } from "@hooks/useData";
 import { useTranslation } from "@hooks/useTranslation";
-import { WindowContext } from "@hooks/useWindow";
 import { get } from "@lib/api";
-import { BREAKPOINTS } from "@lib/constants";
 import { useTheme } from "next-themes";
 import dynamic from "next/dynamic";
-import { FunctionComponent, ReactNode, useContext } from "react";
+import { FunctionComponent, ReactNode } from "react";
 import { toast } from "@components/Toast";
 import { clx } from "@lib/helpers";
 /**
@@ -24,12 +22,14 @@ import { clx } from "@lib/helpers";
 
 const Bar = dynamic(() => import("@components/Chart/Bar"), { ssr: false });
 
-interface NamePopularityDashboardProps {}
+interface NamePopularityDashboardProps {
+  top_names: Record<string, any>;
+}
 
-const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> = () => {
+const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> = ({
+  top_names,
+}) => {
   const { t } = useTranslation(["dashboard-name-popularity", "common"]);
-  const { size } = useContext(WindowContext);
-  const showPlaceholder = size.width >= BREAKPOINTS.LG;
 
   const { data: searchData, setData: setSearchData } = useData({
     type: { label: t("first_name"), value: "first" },

--- a/apps/app/dashboards/demography/name-popularity/index.tsx
+++ b/apps/app/dashboards/demography/name-popularity/index.tsx
@@ -6,7 +6,7 @@ import { Button, Container, Hero, Input, Radio, Section } from "@components/inde
 import Toggle from "@components/Toggle";
 import Spinner from "@components/Spinner";
 import { OptionType } from "@components/types";
-import { MagnifyingGlassIcon } from "@heroicons/react/20/solid";
+import { MagnifyingGlassIcon, LockClosedIcon } from "@heroicons/react/20/solid";
 import { useData } from "@hooks/useData";
 import { useTranslation } from "@hooks/useTranslation";
 import { WindowContext } from "@hooks/useWindow";
@@ -14,7 +14,7 @@ import { get } from "@lib/api";
 import { BREAKPOINTS } from "@lib/constants";
 import { useTheme } from "next-themes";
 import dynamic from "next/dynamic";
-import { FunctionComponent, useContext } from "react";
+import { FunctionComponent, ReactNode, useContext } from "react";
 import { toast } from "@components/Toast";
 import { clx } from "@lib/helpers";
 /**
@@ -92,6 +92,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
     get("/explorer", params)
       .then(({ data }) => {
         setSearchData("data", data.data);
+        setSearchData("private", data.data?.count === null);
         setSearchData("loading", false);
       })
       .catch(e => {
@@ -178,6 +179,32 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
     count: [10004, 13409, 30904, 43434, 50694, 75443, 70530, 78667, 62537, 15519],
   };
 
+  const renderPlaceholderBar = (icon: ReactNode, prompt_key: string) => (
+    <div className="relative hidden h-[460px] w-full items-center justify-center lg:flex">
+      <Bar
+        className="absolute top-0 h-[460px] w-full opacity-10"
+        precision={0}
+        data={{
+          labels: placeholderData.decade,
+          datasets: [
+            {
+              data: placeholderData.count,
+              borderRadius: 12,
+              barThickness: 12,
+              backgroundColor: theme === "light" ? "#71717A" : "#FFFFFF",
+            },
+          ],
+        }}
+        enableGridX={false}
+        tooltipEnabled={false}
+      />
+      <Card className="border-outline bg-outline dark:border-washed-dark dark:bg-washed-dark z-10 flex h-min w-fit flex-row items-center gap-2 rounded-md border px-3 py-1.5 md:mx-auto">
+        {icon}
+        <p>{t(prompt_key)}</p>
+      </Card>
+    </div>
+  );
+
   return (
     <>
       <Hero
@@ -253,6 +280,30 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                     <div className="flex h-[460px] items-center justify-center">
                       <Spinner loading={searchData.loading} />
                     </div>
+                  ) : searchData.private ? (
+                    <div className="space-y-4">
+                      <div>
+                        <p className="text-lg font-bold">
+                          <span>
+                            {t(`bar_title_${searchData.params.type}`, {
+                              count: searchData.data.total || 0,
+                            })}
+                          </span>
+                          <span>{`"${searchData.params.name}".`}</span>
+                        </p>
+                        <p className="text-dim text-sm">
+                          <span>
+                            {t("bar_description", {
+                              name: searchData.params.name,
+                            })}
+                          </span>
+                        </p>
+                      </div>
+                      {renderPlaceholderBar(
+                        <LockClosedIcon className="h-4 w-4" />,
+                        t("To preserve privacy, timeseries data for this name is not displayed.")
+                      )}
+                    </div>
                   ) : (
                     <Bar
                       precision={0}
@@ -284,7 +335,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                         datasets: [
                           {
                             data: searchData.data.count,
-                            label: "Similar names",
+                            label: t("similar_names"),
                             borderRadius: 12,
                             barThickness: 12,
                             backgroundColor: theme === "light" ? "#18181B" : "#FFFFFF",
@@ -296,28 +347,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                   )}
                 </div>
               ) : (
-                <div className="relative hidden h-[460px] w-full items-center justify-center lg:flex">
-                  <Bar
-                    className="absolute top-0 h-[460px] w-full opacity-30"
-                    data={{
-                      labels: placeholderData.decade,
-                      datasets: [
-                        {
-                          data: placeholderData.count,
-                          borderRadius: 12,
-                          barThickness: 12,
-                          backgroundColor: theme === "light" ? "#71717A" : "#FFFFFF",
-                        },
-                      ],
-                    }}
-                    enableGridX={false}
-                    tooltipEnabled={false}
-                  />
-                  <Card className="border-outline bg-outline dark:border-washed-dark dark:bg-washed-dark z-10 flex h-min w-fit flex-row items-center gap-2 rounded-md border px-3 py-1.5 md:mx-auto">
-                    <MagnifyingGlassIcon className=" h-4 w-4" />
-                    <p>{t("search_prompt")}</p>
-                  </Card>
-                </div>
+                renderPlaceholderBar(<MagnifyingGlassIcon className="h-4 w-4" />, "search_prompt")
               )}
             </div>
           </div>

--- a/apps/app/dashboards/demography/name-popularity/index.tsx
+++ b/apps/app/dashboards/demography/name-popularity/index.tsx
@@ -37,6 +37,7 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
     params: {},
     data: null,
     loading: false,
+    private: false,
   });
 
   const { data: compareData, setData: setCompareData } = useData({
@@ -244,88 +245,80 @@ const NamePopularityDashboard: FunctionComponent<NamePopularityDashboardProps> =
                 <p className="text-dim text-sm">{t("search_disclaimer")}</p>
               </Card>
             </div>
-            {!showPlaceholder && !searchData.data ? (
-              <></>
-            ) : (
-              <div
-                className={
-                  "col-span-full flex max-h-fit place-content-center place-items-center lg:col-span-2"
-                }
-              >
-                {searchData.data ? (
-                  <div className="w-full">
-                    {searchData.loading ? (
-                      <div className="flex h-[460px] items-center justify-center">
-                        <Spinner loading={searchData.loading} />
-                      </div>
-                    ) : (
-                      <Bar
-                        precision={0}
-                        suggestedMaxY={5}
-                        className="h-[460px]"
-                        title={
-                          <>
-                            <p className="text-lg font-bold">
-                              <span>
-                                {t(`bar_title_${searchData.params.type}`, {
-                                  count: searchData.data.total || 0,
-                                })}
-                              </span>
-                              <span>{`"${searchData.params.name}".`}</span>
-                            </p>
-                            <p className="text-dim text-sm">
-                              <span>
-                                {t("bar_description", {
-                                  name: searchData.params.name,
-                                })}
-                              </span>
-                            </p>
-                          </>
-                        }
-                        data={{
-                          labels: searchData.data.decade
-                            ? searchData.data.decade.map((x: string) => x.toString().concat("s"))
-                            : placeholderData.decade,
-                          datasets: [
-                            {
-                              data: searchData.data.count,
-                              label: "Similar names",
-                              borderRadius: 12,
-                              barThickness: 12,
-                              backgroundColor: theme === "light" ? "#18181B" : "#FFFFFF",
-                            },
-                          ],
-                        }}
-                        enableGridX={false}
-                      />
-                    )}
-                  </div>
-                ) : (
-                  <div className="relative flex h-[460px] w-full items-center justify-center">
+            <div className="col-span-full flex max-h-fit place-content-center place-items-center lg:col-span-2">
+              {searchData.data ? (
+                <div className="w-full">
+                  {searchData.loading ? (
+                    <div className="flex h-[460px] items-center justify-center">
+                      <Spinner loading={searchData.loading} />
+                    </div>
+                  ) : (
                     <Bar
-                      className="absolute top-0 h-[460px] w-full opacity-30"
+                      precision={0}
+                      suggestedMaxY={5}
+                      className="h-[460px]"
+                      title={
+                        <>
+                          <p className="text-lg font-bold">
+                            <span>
+                              {t(`bar_title_${searchData.params.type}`, {
+                                count: searchData.data.total || 0,
+                              })}
+                            </span>
+                            <span>{`"${searchData.params.name}".`}</span>
+                          </p>
+                          <p className="text-dim text-sm">
+                            <span>
+                              {t("bar_description", {
+                                name: searchData.params.name,
+                              })}
+                            </span>
+                          </p>
+                        </>
+                      }
                       data={{
-                        labels: placeholderData.decade,
+                        labels: searchData.data.decade
+                          ? searchData.data.decade.map((x: string) => x.toString().concat("s"))
+                          : placeholderData.decade,
                         datasets: [
                           {
-                            data: placeholderData.count,
+                            data: searchData.data.count,
+                            label: "Similar names",
                             borderRadius: 12,
                             barThickness: 12,
-                            backgroundColor: theme === "light" ? "#71717A" : "#FFFFFF",
+                            backgroundColor: theme === "light" ? "#18181B" : "#FFFFFF",
                           },
                         ],
                       }}
                       enableGridX={false}
-                      tooltipEnabled={false}
                     />
-                    <Card className="border-outline bg-outline dark:border-washed-dark dark:bg-washed-dark z-10 flex h-min w-fit flex-row items-center gap-2 rounded-md border px-3 py-1.5 md:mx-auto">
-                      <MagnifyingGlassIcon className=" h-4 w-4" />
-                      <p>{t("search_prompt")}</p>
-                    </Card>
-                  </div>
-                )}
-              </div>
-            )}
+                  )}
+                </div>
+              ) : (
+                <div className="relative hidden h-[460px] w-full items-center justify-center lg:flex">
+                  <Bar
+                    className="absolute top-0 h-[460px] w-full opacity-30"
+                    data={{
+                      labels: placeholderData.decade,
+                      datasets: [
+                        {
+                          data: placeholderData.count,
+                          borderRadius: 12,
+                          barThickness: 12,
+                          backgroundColor: theme === "light" ? "#71717A" : "#FFFFFF",
+                        },
+                      ],
+                    }}
+                    enableGridX={false}
+                    tooltipEnabled={false}
+                  />
+                  <Card className="border-outline bg-outline dark:border-washed-dark dark:bg-washed-dark z-10 flex h-min w-fit flex-row items-center gap-2 rounded-md border px-3 py-1.5 md:mx-auto">
+                    <MagnifyingGlassIcon className=" h-4 w-4" />
+                    <p>{t("search_prompt")}</p>
+                  </Card>
+                </div>
+              )}
+            </div>
           </div>
         </Section>
 

--- a/apps/app/pages/dashboard/name-popularity/index.tsx
+++ b/apps/app/pages/dashboard/name-popularity/index.tsx
@@ -19,6 +19,7 @@ const NamePopularity: Page = ({ meta }: InferGetStaticPropsType<typeof getStatic
 
 export const getStaticProps: GetStaticProps = withi18n("dashboard-name-popularity", async () => {
   return {
+    notFound: process.env.NEXT_PUBLIC_APP_ENV === "production",
     props: {
       meta: {
         id: "dashboard-name-popularity",

--- a/apps/app/pages/dashboard/name-popularity/index.tsx
+++ b/apps/app/pages/dashboard/name-popularity/index.tsx
@@ -10,13 +10,19 @@ import { GetStaticProps, InferGetStaticPropsType } from "next";
 const NamePopularity: Page = ({
   meta,
   top_names,
+  yearDropdown,
+  ethnicityDropdown,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const { t } = useTranslation(["dashboard-name-popularity", "common"]);
 
   return (
     <AnalyticsProvider meta={meta}>
       <Metadata title={t("header")} description={t("description")} keywords={""} />
-      <NamePopularityDashboard top_names={top_names} />
+      <NamePopularityDashboard
+        top_names={top_names}
+        yearDropdown={yearDropdown}
+        ethnicityDropdown={ethnicityDropdown}
+      />
     </AnalyticsProvider>
   );
 };
@@ -36,6 +42,8 @@ export const getStaticProps: GetStaticProps = withi18n("dashboard-name-popularit
         agency: "JPN",
       },
       top_names: data.top_names.data,
+      yearDropdown: data.year_dropdown.data.data,
+      ethnicityDropdown: data.ethnicity_dropdown.data.data,
     },
   };
 });

--- a/apps/app/pages/dashboard/name-popularity/index.tsx
+++ b/apps/app/pages/dashboard/name-popularity/index.tsx
@@ -2,22 +2,30 @@ import Metadata from "@components/Metadata";
 import NamePopularityDashboard from "@dashboards/demography/name-popularity";
 import { AnalyticsProvider } from "@hooks/useAnalytics";
 import { useTranslation } from "@hooks/useTranslation";
+import { get } from "@lib/api";
 import { withi18n } from "@lib/decorators";
 import { Page } from "@lib/types";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
 
-const NamePopularity: Page = ({ meta }: InferGetStaticPropsType<typeof getStaticProps>) => {
+const NamePopularity: Page = ({
+  meta,
+  top_names,
+}: InferGetStaticPropsType<typeof getStaticProps>) => {
   const { t } = useTranslation(["dashboard-name-popularity", "common"]);
 
   return (
     <AnalyticsProvider meta={meta}>
       <Metadata title={t("header")} description={t("description")} keywords={""} />
-      <NamePopularityDashboard />
+      <NamePopularityDashboard top_names={top_names} />
     </AnalyticsProvider>
   );
 };
 
 export const getStaticProps: GetStaticProps = withi18n("dashboard-name-popularity", async () => {
+  const { data } = await get("/dashboard", { dashboard: "name_popularity" }).catch(e => {
+    throw new Error("Name Popularity data was not fetched properly. " + e);
+  });
+
   return {
     notFound: process.env.NEXT_PUBLIC_APP_ENV === "production",
     props: {
@@ -27,6 +35,7 @@ export const getStaticProps: GetStaticProps = withi18n("dashboard-name-popularit
         category: "demography",
         agency: "JPN",
       },
+      top_names: data.top_names.data,
     },
   };
 });


### PR DESCRIPTION
## Changes made
1.  Added `notFound: process.env.NEXT_PUBLIC_APP_ENV === "production"` to the getStaticProps for name popularity dashboard to hide page in production.
2. Fetched table and dropdown data from BE for new top section.
3. Handled private name data - for private data, BE returns null for certain fields, e.g. `count` and `decade` arrays are empty if the name data is private, this is reflected on FE by showing a placeholder chart with a private data prompt in the text box. (for the bottom table, tooltip with lock icon is shown)
4. Bar chart precision is fixed through the Bar component (updated hardcoded value to `precision` prop at https://github.com/data-gov-my/datagovmy-front/pull/180/commits/c5ea7ab3c7eae6199bbbf27b8df970a73b58de55)