### PR TITLE
Fix/openapi

### DIFF
--- a/apps/app/data-catalogue/show.tsx
+++ b/apps/app/data-catalogue/show.tsx
@@ -572,7 +572,12 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
         </Section>
 
         {/* API Request Code */}
-        {!config.exclude_openapi && (
+        {config.exclude_openapi ? (
+          <Section
+            title={t("sample_query.section_title")}
+            description={t("sample_query.unavailable")}
+          />
+        ) : (
           <Section
             title={t("sample_query.section_title")}
             description={
@@ -582,7 +587,7 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
                   className="link-dim text-base underline"
                   href={`https://developer.data.gov.my${
                     i18n.language === "en-GB" ? "" : "/ms"
-                  }/data-catalogue/request-query`}
+                  }/data-catalogue`}
                   external
                 >
                   {t("sample_query.link1")}
@@ -592,7 +597,7 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
                   className="link-dim text-base underline"
                   href={`https://developer.data.gov.my/${
                     i18n.language == "en-GB" ? "" : "/ms"
-                  }/data-catalogue/example-requests?id=${catalogueId}`}
+                  }/data-catalogue?id=${catalogueId}`}
                   external
                 >
                   {t("sample_query.link2")}

--- a/apps/app/pages/data-catalogue/[id].tsx
+++ b/apps/app/pages/data-catalogue/[id].tsx
@@ -150,7 +150,7 @@ export const getServerSideProps: GetServerSideProps = withi18n(
         },
         urls: data.downloads ?? {},
         translations: data.translations ?? {},
-        catalogueId: params?.id,
+        catalogueId: data.openapi_id,
       },
     };
   }


### PR DESCRIPTION
## Changes made
1. `openapi_id` is now added into BE response, and is passed to FE. The sample OpenAPI code section now uses this `openapi_id` as the query param.

> Description explaining why it's not available, a standard one for all
3. Per above feedback - Instead of removing the section, the bottom section is rendered even when `exclude_openapi` is True, it shows an unavailable prompt.