### PR TITLE
chore: delete outdated content

### DIFF
--- a/apps/app/data-catalogue/show.tsx
+++ b/apps/app/data-catalogue/show.tsx
@@ -597,20 +597,10 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
                   className="link-dim text-base underline"
                   href={`https://developer.data.gov.my${
                     i18n.language === "en-GB" ? "" : "/ms"
-                  }/data-catalogue`}
+                  }/static-api/data-catalogue`}
                   external
                 >
                   {t("sample_query.link1")}
-                </At>
-                <span>{`. ${t("sample_query.desc2")}`}</span>
-                <At
-                  className="link-dim text-base underline"
-                  href={`https://developer.data.gov.my/${
-                    i18n.language == "en-GB" ? "" : "/ms"
-                  }/data-catalogue?id=${catalogueId}`}
-                  external
-                >
-                  {t("sample_query.link2")}
                 </At>
                 .
               </>

--- a/apps/opendosm/data-catalogue/show.tsx
+++ b/apps/opendosm/data-catalogue/show.tsx
@@ -583,16 +583,6 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
                 >
                   {t("sample_query.link1")}
                 </At>
-                <span>{`. ${t("sample_query.desc2")}`}</span>
-                <At
-                  className="link-dim text-base underline"
-                  href={`https://developer.data.gov.my/${
-                    i18n.language == "en-GB" ? "" : "/ms"
-                  }/data-catalogue?id=${catalogueId}`}
-                  external
-                >
-                  {t("sample_query.link2")}
-                </At>
                 .
               </>
             }


### PR DESCRIPTION
OpenAPI docs no longer has the live query testing component, hence the description regarding interactive exploration on docs site is inaccurate and should be removed.

Changes made in this PR:
The following code is an example of how to make an API query to retrieve the data catalogue mentioned above. You can use different programming languages by switching the code accordingly. For a complete guide on possible query parameters and syntax, please refer to the [official Open API documentation](https://developer.data.gov.my/data-catalogue). ~~Additionally, you can experiment with the code interactively and send requests at the [Example Requests section](https://developer.data.gov.my//data-catalogue?id=fuelprice).~~
