### PR TITLE
Fix/slider default start

### DIFF
--- a/apps/app/dashboards/economy/income-taxation/index.tsx
+++ b/apps/app/dashboards/economy/income-taxation/index.tsx
@@ -14,6 +14,7 @@ import Taxpayers, { TaxpayersProps } from "./taxpayers";
 interface IncomeTaxationProps extends TaxpayersProps {
   last_updated: string;
   stacked_bar: any;
+  year: number;
 }
 
 const IncomeTaxation: FunctionComponent<IncomeTaxationProps> = ({
@@ -21,6 +22,7 @@ const IncomeTaxation: FunctionComponent<IncomeTaxationProps> = ({
   stacked_bar,
   timeseries,
   timeseries_callout,
+  year,
 }) => {
   const { t } = useTranslation("dashboard-income-taxation");
 
@@ -37,7 +39,7 @@ const IncomeTaxation: FunctionComponent<IncomeTaxationProps> = ({
 
       <Container>
         {/* How do I compare to other taxpayers in Malaysia? */}
-        <IncomeRank />
+        <IncomeRank year={year} />
 
         {/* How many people pay tax each year? */}
         <Taxpayers timeseries={timeseries} timeseries_callout={timeseries_callout} />

--- a/apps/app/dashboards/economy/income-taxation/rank-me.tsx
+++ b/apps/app/dashboards/economy/income-taxation/rank-me.tsx
@@ -31,7 +31,11 @@ type Percentile = {
 
 type PercentileKeys = keyof Percentile;
 
-const IncomeRank: FunctionComponent = () => {
+interface IncomeRankProps {
+  year: number;
+}
+
+const IncomeRank: FunctionComponent<IncomeRankProps> = ({ year }) => {
   const { t, i18n } = useTranslation(["dashboard-income-taxation", "common"]);
   const barRef = useRef<HTMLParagraphElement>(null);
   const { size } = useContext(WindowContext);
@@ -103,6 +107,7 @@ const IncomeRank: FunctionComponent = () => {
             setResult(key, biggest[key]);
           }
         }
+        setData("loading", false);
       })
       .catch(e => {
         toast.error(
@@ -111,7 +116,6 @@ const IncomeRank: FunctionComponent = () => {
         );
         console.error(e);
       });
-    setTimeout(() => setData("loading", false), 400);
   };
 
   const handleChange = (e: string) => {
@@ -201,22 +205,21 @@ const IncomeRank: FunctionComponent = () => {
             {t("rank_me")}
           </button>
           <p ref={barRef} className="text-dim text-sm">
-            {/* FIXME: year */}
-            {t("disclaimer", { year: 2022 })}
+            {t("disclaimer", { year: year })}
           </p>
         </Card>
         <div className="w-full sm:w-7/12 lg:w-2/3">
-          {typeof result.percentile !== "number" ? (
+          {data.loading ? (
+            <div className="shadow-button border-outline dark:border-washed-dark flex h-full w-full items-center justify-center rounded-xl border">
+              <Spinner loading={data.loading} />
+            </div>
+          ) : typeof result.percentile !== "number" ? (
             <Card className="border-outline dark:border-washed-dark hidden h-full items-center gap-6 rounded-xl border p-8 sm:flex">
               <Card className="border-outline bg-outline dark:border-washed-dark dark:bg-washed-dark mx-auto flex h-min w-fit flex-row gap-2 self-center rounded-md border px-3 py-1.5">
                 <MagnifyingGlassIcon className="mx-auto mt-1 h-4 w-4 text-black dark:text-white" />
                 <p>{t("start_search")}</p>
               </Card>
             </Card>
-          ) : data.loading ? (
-            <div className="shadow-button border-outline dark:border-washed-dark flex h-full w-full items-center justify-center rounded-xl border">
-              <Spinner loading={data.loading} />
-            </div>
           ) : (
             <div className="border-outline dark:border-washed-dark dark:divide-washed-dark shadow-button flex flex-col rounded-xl border max-lg:divide-y lg:flex-row lg:divide-x">
               <div className="bg-background dark:bg-background-dark/50 flex h-auto w-full flex-col items-center gap-6 p-6 max-lg:rounded-t-xl lg:h-[400px] lg:w-1/2 lg:rounded-l-xl lg:p-8">
@@ -268,7 +271,7 @@ const IncomeRank: FunctionComponent = () => {
                         : t("assessment", { context: result.assessment }),
                     aged: result.age === "all" ? "" : `${t("aged")} ${t(result.age)}`,
                     state: CountryAndStates[result.state],
-                    year: 2022, // FIXME: year
+                    year: year,
                   })}
                 </p>
               </div>

--- a/apps/app/dashboards/economy/income-taxation/rank-me.tsx
+++ b/apps/app/dashboards/economy/income-taxation/rank-me.tsx
@@ -115,6 +115,7 @@ const IncomeRank: FunctionComponent<IncomeRankProps> = ({ year }) => {
           t("common:error.toast.reach_support")
         );
         console.error(e);
+        setData("loading", false);
       });
   };
 

--- a/apps/app/dashboards/economy/income-taxation/rank-me.tsx
+++ b/apps/app/dashboards/economy/income-taxation/rank-me.tsx
@@ -107,7 +107,6 @@ const IncomeRank: FunctionComponent<IncomeRankProps> = ({ year }) => {
             setResult(key, biggest[key]);
           }
         }
-        setData("loading", false);
       })
       .catch(e => {
         toast.error(
@@ -115,8 +114,8 @@ const IncomeRank: FunctionComponent<IncomeRankProps> = ({ year }) => {
           t("common:error.toast.reach_support")
         );
         console.error(e);
-        setData("loading", false);
-      });
+      })
+      .finally(() => setData("loading", false));
   };
 
   const handleChange = (e: string) => {

--- a/apps/app/dashboards/transportation/ktmb-explorer/index.tsx
+++ b/apps/app/dashboards/transportation/ktmb-explorer/index.tsx
@@ -225,11 +225,10 @@ const KTMBExplorer: FunctionComponent<KTMBExplorerProps> = ({
                   )}
                 </Modal>
               </div>
-              <div className="hidden gap-2 sm:flex lg:gap-3">
+              <div className="hidden gap-2 sm:flex sm:flex-wrap lg:gap-3">
                 <Dropdown
                   placeholder={t("service")}
                   anchor="left"
-                  width="min-w-[150px] w-auto"
                   options={SERVICE_OPTIONS}
                   selected={SERVICE_OPTIONS.find(e => e.value === data.service)}
                   onChange={selected => {
@@ -241,7 +240,6 @@ const KTMBExplorer: FunctionComponent<KTMBExplorerProps> = ({
                 <Dropdown
                   placeholder={t("select_origin")}
                   anchor="left"
-                  width="min-w-[210px] w-auto"
                   options={ORIGIN_OPTIONS}
                   selected={ORIGIN_OPTIONS.find(e => e.value === data.origin)}
                   disabled={!data.service}
@@ -254,7 +252,6 @@ const KTMBExplorer: FunctionComponent<KTMBExplorerProps> = ({
                 <Dropdown
                   placeholder={t("select_destination")}
                   anchor="left"
-                  width="min-w-[210px] w-auto"
                   options={DESTINATION_OPTIONS}
                   selected={DESTINATION_OPTIONS.find(e => e.value === data.destination)}
                   disabled={!data.service || !data.origin}
@@ -288,7 +285,6 @@ const KTMBExplorer: FunctionComponent<KTMBExplorerProps> = ({
                       <Timeseries
                         className="h-[300px] w-full"
                         title={t("ridership", {
-                          context: config.period,
                           from: params.origin ?? DEFAULT_ORIG,
                           to: params.destination ?? DEFAULT_DEST,
                         })}
@@ -326,7 +322,6 @@ const KTMBExplorer: FunctionComponent<KTMBExplorerProps> = ({
                         <Timeseries
                           className="h-[300px] w-full"
                           title={t("ridership", {
-                            context: config.period,
                             from: params.destination ?? DEFAULT_DEST,
                             to: params.origin ?? DEFAULT_ORIG,
                           })}
@@ -364,7 +359,6 @@ const KTMBExplorer: FunctionComponent<KTMBExplorerProps> = ({
                         <div className="relative flex h-[400px] w-full flex-col">
                           <h5>
                             {t("ridership", {
-                              context: config.period,
                               from: params.destination ?? DEFAULT_DEST,
                               to: params.origin ?? DEFAULT_ORIG,
                             })}

--- a/apps/app/dashboards/transportation/rapid-explorer/index.tsx
+++ b/apps/app/dashboards/transportation/rapid-explorer/index.tsx
@@ -56,7 +56,7 @@ const RapidExplorer: FunctionComponent<RapidExplorerProps> = ({
   const { data, setData } = useData({
     loading: false,
     minmax: [0, A_to_B.data.daily.x.length - 1],
-    service: params.service,
+    service: "rail", // FIXME if adding other services: params.service,
     origin: params.origin,
     destination: params.destination,
     tab: 0,
@@ -89,6 +89,12 @@ const RapidExplorer: FunctionComponent<RapidExplorerProps> = ({
   );
   const LATEST_MONTH = A_to_B.data.monthly.x[A_to_B.data.monthly.x.length - 1];
 
+  const isAllStations = (station: string) => {
+    if (station === "A0: All Stations") {
+      return t("all_stations");
+    } else return station;
+  };
+
   const SERVICE_OPTIONS = useMemo<Array<OptionType>>(() => {
     const _services = Object.keys(dropdown).map(service => ({ label: t(service), value: service }));
     return _services;
@@ -98,7 +104,7 @@ const RapidExplorer: FunctionComponent<RapidExplorerProps> = ({
     let _origins: Array<OptionType> = [];
     if (data.service) {
       _origins = Object.keys(dropdown[data.service]).map(origin => ({
-        label: origin,
+        label: isAllStations(origin),
         value: origin,
       }));
     }
@@ -108,8 +114,8 @@ const RapidExplorer: FunctionComponent<RapidExplorerProps> = ({
   const DESTINATION_OPTIONS = useMemo<Array<OptionType>>(() => {
     let _destinations: Array<OptionType> = [];
     if (data.service && data.origin) {
-      _destinations = dropdown[data.service][data.origin].map((destination: string) => ({
-        label: destination,
+      _destinations = dropdown[data.service][data.origin].map(destination => ({
+        label: isAllStations(destination),
         value: destination,
       }));
     }
@@ -245,11 +251,10 @@ const RapidExplorer: FunctionComponent<RapidExplorerProps> = ({
                           )}
                         </Modal>
                       </div>
-                      <div className="hidden gap-2 sm:flex lg:gap-3">
+                      <div className="hidden gap-2 sm:flex sm:flex-wrap lg:gap-3">
                         <Dropdown
                           placeholder={t("service")}
                           anchor="left"
-                          width="min-w-[100px] w-auto"
                           options={SERVICE_OPTIONS}
                           selected={SERVICE_OPTIONS.find(e => e.value === data.service)}
                           onChange={selected => {
@@ -261,7 +266,6 @@ const RapidExplorer: FunctionComponent<RapidExplorerProps> = ({
                         <Dropdown
                           placeholder={t("select_origin")}
                           anchor="left"
-                          width="min-w-[250px] w-auto"
                           options={ORIGIN_OPTIONS}
                           selected={ORIGIN_OPTIONS.find(e => e.value === data.origin)}
                           disabled={!data.service}
@@ -274,7 +278,6 @@ const RapidExplorer: FunctionComponent<RapidExplorerProps> = ({
                         <Dropdown
                           placeholder={t("select_destination")}
                           anchor="left"
-                          width="min-w-[250px] w-auto"
                           options={DESTINATION_OPTIONS}
                           selected={DESTINATION_OPTIONS.find(e => e.value === data.destination)}
                           disabled={!data.service || !data.origin}
@@ -290,9 +293,8 @@ const RapidExplorer: FunctionComponent<RapidExplorerProps> = ({
                       <Timeseries
                         className="h-[300px] w-full"
                         title={t("ridership", {
-                          context: config.period,
-                          from: params.origin ?? DEFAULT_ORIG,
-                          to: params.destination ?? DEFAULT_DEST,
+                          from: isAllStations(params.origin) ?? DEFAULT_ORIG,
+                          to: isAllStations(params.destination) ?? DEFAULT_DEST,
                         })}
                         enableAnimation={!play}
                         interval={config.period}
@@ -328,9 +330,8 @@ const RapidExplorer: FunctionComponent<RapidExplorerProps> = ({
                         <Timeseries
                           className="h-[300px] w-full"
                           title={t("ridership", {
-                            context: config.period,
-                            from: params.destination ?? DEFAULT_DEST,
-                            to: params.origin ?? DEFAULT_ORIG,
+                            from: isAllStations(params.destination) ?? DEFAULT_DEST,
+                            to: isAllStations(params.origin) ?? DEFAULT_ORIG,
                           })}
                           enableAnimation={!play}
                           interval={config.period}
@@ -366,9 +367,8 @@ const RapidExplorer: FunctionComponent<RapidExplorerProps> = ({
                         <div className="relative flex h-[400px] w-full flex-col lg:h-full">
                           <h5>
                             {t("ridership", {
-                              context: config.period,
-                              from: params.destination ?? DEFAULT_DEST,
-                              to: params.origin ?? DEFAULT_ORIG,
+                              from: isAllStations(params.destination) ?? DEFAULT_DEST,
+                              to: isAllStations(params.origin) ?? DEFAULT_ORIG,
                             })}
                           </h5>
                           <Timeseries

--- a/apps/app/data-catalogue/index.tsx
+++ b/apps/app/data-catalogue/index.tsx
@@ -120,7 +120,7 @@ const CatalogueIndex: FunctionComponent<CatalogueIndexProps> = ({ query, collect
                   title={title}
                   key={title}
                   ref={ref => (scrollRef.current[title] = ref)}
-                  className="p-2 pb-8 pt-14 lg:p-8"
+                  className="p-2 py-6 first-of-type:max-lg:pb-6 first-of-type:max-lg:pt-14 lg:p-8"
                 >
                   <ul className="columns-1 space-y-3 sm:columns-3">
                     {datasets.map((item: Catalogue, index: number) => (

--- a/apps/app/data-catalogue/show.tsx
+++ b/apps/app/data-catalogue/show.tsx
@@ -641,7 +641,7 @@ const DownloadCard: FunctionComponent<DownloadCard> = ({
         {["svg", "png"].includes(id) ? (
           <Image
             src={image || ""}
-            className="aspect-video h-14 rounded border bg-white object-cover lg:h-16"
+            className="dark:border-dim aspect-video h-14 rounded border bg-white object-cover dark:bg-black lg:h-16"
             width={128}
             height={64}
             alt={title as string}

--- a/apps/app/pages/404.tsx
+++ b/apps/app/pages/404.tsx
@@ -13,7 +13,7 @@ const ActiveLink = ({ children, className, ...props }: ComponentProps<"a">) => {
   useEffect(() => {
     // Check if the router fields are updated client-side
     if (isReady) {
-      setLegacyPath(asPath);
+      setLegacyPath(`https://archive.data.gov.my${asPath}`);
     }
   }, [isReady]);
 

--- a/apps/app/pages/404.tsx
+++ b/apps/app/pages/404.tsx
@@ -1,9 +1,28 @@
-import { At, Container, ErrorStatus, Metadata } from "datagovmy-ui/components";
+import { Container, ErrorStatus, Metadata } from "datagovmy-ui/components";
 import { withi18n } from "datagovmy-ui/decorators";
 import { useTranslation } from "datagovmy-ui/hooks";
 import { Page } from "datagovmy-ui/types";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
 import { useRouter } from "next/router";
+import { ComponentProps, useEffect, useState } from "react";
+
+const ActiveLink = ({ children, className, ...props }: ComponentProps<"a">) => {
+  const { asPath, isReady } = useRouter();
+  const [legacyPath, setLegacyPath] = useState<string>(props.href as string);
+
+  useEffect(() => {
+    // Check if the router fields are updated client-side
+    if (isReady) {
+      setLegacyPath(asPath);
+    }
+  }, [isReady]);
+
+  return (
+    <a href={legacyPath} className={className} target="_blank">
+      {children}
+    </a>
+  );
+};
 
 const Error404: Page = ({}: InferGetStaticPropsType<typeof getStaticProps>) => {
   const { t } = useTranslation("common");
@@ -18,9 +37,7 @@ const Error404: Page = ({}: InferGetStaticPropsType<typeof getStaticProps>) => {
           description={
             <>
               {`${t("error.404.description")} ${t("error.404.legacy")}`}
-              <At external href={"https://archive.data.gov.my"} className="link-primary">
-                archive.data.gov.my
-              </At>
+              <ActiveLink className="link-primary">{"https://archive.data.gov.my"}</ActiveLink>
             </>
           }
           code={404}

--- a/apps/app/pages/dashboard/income-taxation/index.tsx
+++ b/apps/app/pages/dashboard/income-taxation/index.tsx
@@ -14,6 +14,7 @@ const IncomeTaxation: Page = ({
   stacked_bar,
   timeseries,
   timeseries_callout,
+  year,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const { t } = useTranslation(["dashboard-income-taxation", "common"]);
 
@@ -26,6 +27,7 @@ const IncomeTaxation: Page = ({
           stacked_bar={stacked_bar}
           timeseries={timeseries}
           timeseries_callout={timeseries_callout}
+          year={year}
         />
       </WindowProvider>
     </AnalyticsProvider>
@@ -33,7 +35,14 @@ const IncomeTaxation: Page = ({
 };
 
 export const getStaticProps: GetStaticProps = withi18n("dashboard-income-taxation", async () => {
-  const { data } = await get("/dashboard", { dashboard: "income_tax" });
+  const { data } = await get("/dashboard", {
+    dashboard: "income_tax",
+    variable: "tax",
+    state: "mys",
+    type: "all",
+    age: "all",
+  });
+
   return {
     notFound: false,
     props: {
@@ -43,6 +52,7 @@ export const getStaticProps: GetStaticProps = withi18n("dashboard-income-taxatio
         category: "economy",
         agency: "LHDN",
       },
+      year: Number(data.tax_percentile.data_as_of.substring(0, 4)) - 1,
       last_updated: data.data_last_updated,
       stacked_bar: data.stacked_bar,
       timeseries: data.timeseries,

--- a/apps/opendosm/data-catalogue/index.tsx
+++ b/apps/opendosm/data-catalogue/index.tsx
@@ -86,7 +86,7 @@ const CatalogueIndex: FunctionComponent<CatalogueIndexProps> = ({ query, collect
                   title={title}
                   key={title}
                   ref={ref => (scrollRef.current[title] = ref)}
-                  className="p-2 pb-8 pt-14 lg:p-8"
+                  className="p-2 py-6 first-of-type:max-lg:pb-6 first-of-type:max-lg:pt-14 lg:p-8"
                 >
                   <ul className="columns-1 space-y-3 lg:columns-2 xl:columns-3">
                     {datasets.map((item: Catalogue, index: number) => (
@@ -181,7 +181,7 @@ const CatalogueFilter: FunctionComponent<CatalogueFilterProps> = ({ query }) => 
   };
 
   return (
-    <div className="sticky top-14 z-10 flex items-center justify-between gap-2 border-b bg-white py-4 dark:border-outlineHover-dark dark:bg-background-dark lg:pl-2">
+    <div className="sticky top-14 z-10 flex items-center justify-between gap-2 border-b bg-white py-3 dark:border-outlineHover-dark dark:bg-background-dark lg:pl-2">
       <div className="flex-grow">
         <Search
           className="border-0"

--- a/apps/opendosm/pages/api/embed.ts
+++ b/apps/opendosm/pages/api/embed.ts
@@ -1,0 +1,32 @@
+import { get } from "datagovmy-ui/api";
+import { SHORT_LANG } from "datagovmy-ui/constants";
+import { DCFilter } from "datagovmy-ui/types";
+import { NextApiRequest, NextApiResponse } from "next";
+
+/**
+ * GET endpoint for embed preview
+ * @param req Request
+ * @param res Response
+ * @returns {RevalidateData} Result
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse<any>) {
+  try {
+    const { id, lang, ...query } = req.query;
+    const { data } = await get("/data-variable/", {
+      id,
+      lang: SHORT_LANG[lang as keyof typeof SHORT_LANG],
+      ...query,
+    });
+
+    return res
+      .setHeader("Cache-Control", "public, s-maxage=21600, stale-while-revalidate=21600") // 30 min
+      .json({
+        params: {
+          id: id ?? null,
+        },
+        options: data.API.filters?.filter((item: DCFilter) => item.key !== "date_slider") ?? null,
+      });
+  } catch (err: any) {
+    return res.status(400).json({ error: "Bad request", authorized: false });
+  }
+}

--- a/packages/datagovmy-ui/src/charts/bar.tsx
+++ b/packages/datagovmy-ui/src/charts/bar.tsx
@@ -39,6 +39,7 @@ interface BarProps extends ChartHeaderProps {
   enableGridY?: boolean;
   enableStack?: boolean;
   enableStep?: boolean;
+  forcedTheme?: string;
   interactive?: boolean;
   tooltipEnabled?: boolean;
   _ref?: ForwardedRef<ChartJSOrUndefined<"bar", any[], string | number>>;
@@ -65,6 +66,7 @@ const Bar: FunctionComponent<BarProps> = ({
   enableStack = false,
   enableGridX = true,
   enableGridY = true,
+  forcedTheme,
   minY,
   maxY,
   suggestedMaxY,
@@ -75,8 +77,8 @@ const Bar: FunctionComponent<BarProps> = ({
   const isVertical = useMemo(() => layout === "vertical", [layout]);
   const { size } = useContext(WindowContext);
   ChartJS.register(CategoryScale, LinearScale, PointElement, BarElement, ChartTooltip, Legend);
-  const { theme = "light" } = useTheme();
-
+  const { theme } = useTheme();
+  const isLightMode = forcedTheme ? forcedTheme === "light" : theme === "light";
   const display = (
     value: number,
     type: "compact" | "standard",
@@ -148,7 +150,7 @@ const Bar: FunctionComponent<BarProps> = ({
           display: enableGridX,
           borderWidth: 1,
           borderDash: [5, 10],
-          color: theme === "light" ? AKSARA_COLOR.OUTLINE : AKSARA_COLOR.WASHED_DARK,
+          color: isLightMode ? AKSARA_COLOR.OUTLINE : AKSARA_COLOR.WASHED_DARK,
           drawTicks: true,
           drawBorder: true,
         },
@@ -188,7 +190,7 @@ const Bar: FunctionComponent<BarProps> = ({
           drawTicks: false,
           drawBorder: false,
           offset: false,
-          color: theme === "light" ? AKSARA_COLOR.OUTLINE : AKSARA_COLOR.WASHED_DARK,
+          color: isLightMode ? AKSARA_COLOR.OUTLINE : AKSARA_COLOR.WASHED_DARK,
           borderDash(ctx) {
             if (ctx.tick.value === 0) return [0, 0];
             return [5, 5];

--- a/packages/datagovmy-ui/src/charts/line.tsx
+++ b/packages/datagovmy-ui/src/charts/line.tsx
@@ -42,6 +42,7 @@ type LineProps = ChartHeaderProps & {
   enableTooltip?: boolean;
   enableCrosshair?: boolean;
   enableLegend?: boolean;
+  forcedTheme?: string;
   tooltipCallback?: (item: TooltipItem<"line">) => string | string[];
   _ref?: ForwardedRef<ChartJSOrUndefined<"line", any[], unknown>>;
 };
@@ -69,6 +70,7 @@ const Line: FunctionComponent<LineProps> = ({
   enableTooltip = false,
   enableCrosshair = false,
   enableLegend = false,
+  forcedTheme,
   tooltipCallback,
   _ref,
 }) => {
@@ -87,6 +89,7 @@ const Line: FunctionComponent<LineProps> = ({
   );
 
   const { theme } = useTheme();
+  const isLightMode = forcedTheme ? forcedTheme === "light" : theme === "light";
 
   const options: ChartCrosshairOption<"line"> = {
     maintainAspectRatio: false,
@@ -106,7 +109,7 @@ const Line: FunctionComponent<LineProps> = ({
         ? {
             line: {
               width: 0,
-              color: theme === "light" ? "#000" : "#FFF",
+              color: isLightMode ? "#000" : "#FFF",
               dashPattern: [6, 4],
             },
             zoom: {

--- a/packages/datagovmy-ui/src/charts/partials/bar.tsx
+++ b/packages/datagovmy-ui/src/charts/partials/bar.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from "next-themes";
 import { CatalogueContext } from "../../contexts/catalogue";
 import { WindowContext } from "../../contexts/window";
 import { BREAKPOINTS, CATALOGUE_COLORS } from "../../lib/constants";
@@ -20,6 +21,8 @@ const CatalogueBar: FunctionComponent<CatalogueBarProps> = ({
   translations,
 }) => {
   const { bind, dataset } = useContext(CatalogueContext);
+  const { forcedTheme } = useTheme();
+
   const { size } = useContext(WindowContext);
   const bar_layout = useMemo<"horizontal" | "vertical">(() => {
     if (dataset.type === "HBAR" || size.width < BREAKPOINTS.MD) return "horizontal";
@@ -59,6 +62,7 @@ const CatalogueBar: FunctionComponent<CatalogueBarProps> = ({
         labels: dataset.chart.x,
         datasets: _datasets,
       }}
+      forcedTheme={forcedTheme}
     />
   );
 };

--- a/packages/datagovmy-ui/src/charts/partials/embed.tsx
+++ b/packages/datagovmy-ui/src/charts/partials/embed.tsx
@@ -68,6 +68,7 @@ const CatalogueEmbed: ForwardRefExoticComponent<CatalogueEmbedProps> = forwardRe
       }
     };
 
+    // This hook is used when different filter options are shown based on a previous filter (eg. KTM stations)
     useWatch(() => {
       get(
         "/api/embed",

--- a/packages/datagovmy-ui/src/charts/partials/line.tsx
+++ b/packages/datagovmy-ui/src/charts/partials/line.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from "next-themes";
 import { Precision } from "../../../types";
 import { CatalogueContext } from "../../contexts/catalogue";
 import { CATALOGUE_COLORS } from "../../lib/constants";
@@ -22,6 +23,7 @@ const CatalogueLine: FunctionComponent<CatalogueLineProps> = ({
   translations,
 }) => {
   const { bind, dataset } = useContext(CatalogueContext);
+  const { forcedTheme } = useTheme();
 
   const getPrecision = (key: string, precision: number | Precision): number | [number, number] => {
     if (!precision) return [1, 0];
@@ -40,7 +42,7 @@ const CatalogueLine: FunctionComponent<CatalogueLineProps> = ({
 
     return sets.map(([key, y], index) => ({
       type: "line",
-      data: (y as number[]).map(e => numFormat(e, "standard", getPrecision(key, config.precision))),
+      data: y as number[], //(y as number[]).map(e => numFormat(e, "standard", getPrecision(key, config.precision))),
       label: translations[key] ?? key,
       fill: sets.length === 1,
       backgroundColor: CATALOGUE_COLORS[index].concat("1A"),
@@ -74,6 +76,7 @@ const CatalogueLine: FunctionComponent<CatalogueLineProps> = ({
       enableTooltip
       enableCrosshair
       enableLegend={_datasets.length > 1}
+      forcedTheme={forcedTheme}
     />
   );
 };

--- a/packages/datagovmy-ui/src/charts/partials/scatter.tsx
+++ b/packages/datagovmy-ui/src/charts/partials/scatter.tsx
@@ -1,6 +1,7 @@
 import { CatalogueContext } from "../../contexts/catalogue";
 import { CATALOGUE_COLORS } from "../../lib/constants";
 import { ChartDataset } from "chart.js";
+import { useTheme } from "next-themes";
 import { default as dynamic } from "next/dynamic";
 import { FunctionComponent, useContext, useMemo } from "react";
 
@@ -16,6 +17,7 @@ const CatalogueScatter: FunctionComponent<CatalogueScatterProps> = ({
   translations,
 }) => {
   const { bind, dataset } = useContext(CatalogueContext);
+  const { forcedTheme } = useTheme();
 
   const _datasets = useMemo<ChartDataset<"scatter", any[]>[]>(() => {
     return dataset.chart.map((item: any, index: number) => ({
@@ -35,6 +37,7 @@ const CatalogueScatter: FunctionComponent<CatalogueScatterProps> = ({
       data={_datasets}
       enableRegression
       enableLegend
+      forcedTheme={forcedTheme}
     />
   );
 };

--- a/packages/datagovmy-ui/src/charts/partials/timeseries.tsx
+++ b/packages/datagovmy-ui/src/charts/partials/timeseries.tsx
@@ -31,7 +31,7 @@ const CatalogueTimeseries: FunctionComponent<CatalogueTimeseriesProps> = ({
     minmax: [0, dataset.chart?.x ? dataset.chart?.x.length - 1 : 0],
   });
   const { coordinate } = useSlice(dataset.chart, data.minmax);
-  const { theme } = useTheme();
+  const { forcedTheme, theme } = useTheme();
 
   const getPrecision = (precision: number | Precision, key?: string): number | [number, number] => {
     if (!precision) return [1, 0];
@@ -55,7 +55,9 @@ const CatalogueTimeseries: FunctionComponent<CatalogueTimeseriesProps> = ({
       label: translations[key] ?? key,
       borderColor: CATALOGUE_COLORS[index],
       backgroundColor:
-        theme === "light" ? NON_OVERLAPPING_BGCOLOR[index] : DARK_NON_OVERLAPPING_BGCOLOR[index],
+        (forcedTheme || theme) === "light"
+          ? NON_OVERLAPPING_BGCOLOR[index]
+          : DARK_NON_OVERLAPPING_BGCOLOR[index],
       borderWidth: 1,
       fill: dataset.type === "STACKED_AREA" || sets.length <= 1,
     }));
@@ -95,6 +97,7 @@ const CatalogueTimeseries: FunctionComponent<CatalogueTimeseriesProps> = ({
                 datasets: _datasets,
               }}
               beginZero={["STACKED_AREA", "INTRADAY"].includes(dataset.type)}
+              forcedTheme={forcedTheme}
             />
             <Slider
               className="pt-4"

--- a/packages/datagovmy-ui/src/charts/partials/timeseries.tsx
+++ b/packages/datagovmy-ui/src/charts/partials/timeseries.tsx
@@ -76,7 +76,6 @@ const CatalogueTimeseries: FunctionComponent<CatalogueTimeseriesProps> = ({
               _ref={ref => bind.chartjs(ref)}
               className={className}
               interval={SHORT_PERIOD[config.range]}
-              round={SHORT_PERIOD[config.range]}
               precision={
                 typeof config.precision === "number"
                   ? config.precision

--- a/packages/datagovmy-ui/src/charts/scatter.tsx
+++ b/packages/datagovmy-ui/src/charts/scatter.tsx
@@ -38,6 +38,7 @@ type ScatterProps = ChartHeaderProps & {
   enableLegend?: boolean;
   enableGridX?: boolean;
   enableGridY?: boolean;
+  forcedTheme?: string;
   _ref?: ForwardedRef<ChartJSOrUndefined<"scatter", any[], unknown>>;
 };
 
@@ -55,6 +56,7 @@ const Scatter: FunctionComponent<ScatterProps> = ({
   enableLegend = false,
   enableGridX = true,
   enableGridY = true,
+  forcedTheme,
   titleX,
   titleY,
   minX,
@@ -73,6 +75,7 @@ const Scatter: FunctionComponent<ScatterProps> = ({
     Legend
   );
   const { theme } = useTheme();
+  const isLightMode = forcedTheme ? forcedTheme === "light" : theme === "light";
 
   const display = (
     value: number,
@@ -85,7 +88,7 @@ const Scatter: FunctionComponent<ScatterProps> = ({
   const titleConfig = (axis: string | undefined) => ({
     display: Boolean(axis),
     text: axis,
-    color: theme === "light" ? AKSARA_COLOR.BLACK : AKSARA_COLOR.DIM,
+    color: isLightMode ? AKSARA_COLOR.BLACK : AKSARA_COLOR.DIM,
     font: {
       size: 14,
       family: "Inter",
@@ -166,7 +169,7 @@ const Scatter: FunctionComponent<ScatterProps> = ({
         ? {
             line: {
               width: 0,
-              color: theme === "light" ? "#000" : "#FFF",
+              color: isLightMode ? "#000" : "#FFF",
               dashPattern: [6, 4],
             },
             zoom: {

--- a/packages/datagovmy-ui/src/charts/timeseries.tsx
+++ b/packages/datagovmy-ui/src/charts/timeseries.tsx
@@ -77,6 +77,7 @@ export interface TimeseriesProps extends ChartHeaderProps {
   enableGridX?: boolean;
   enableGridY?: boolean;
   enableMajorTick?: boolean;
+  forcedTheme?: string;
   tickXCallback?: (
     this: Scale,
     tickValue: number | string,
@@ -131,6 +132,7 @@ const Timeseries: FunctionComponent<TimeseriesProps> = ({
   tooltipItemSort,
   generateLabels,
   tickXCallback,
+  forcedTheme,
   beginZero = true,
   minY,
   maxY,
@@ -157,7 +159,8 @@ const Timeseries: FunctionComponent<TimeseriesProps> = ({
     AnnotationPlugin
   );
 
-  const { theme = "light" } = useTheme();
+  const { theme } = useTheme();
+  const isLightMode = forcedTheme ? forcedTheme === "light" : theme === "light";
 
   const display = (
     value: number,
@@ -291,7 +294,7 @@ const Timeseries: FunctionComponent<TimeseriesProps> = ({
           ? {
               line: {
                 width: 0,
-                color: theme === "light" ? "#000" : "#FFF",
+                color: isLightMode ? "#000" : "#FFF",
                 dashPattern: [6, 4],
               },
               zoom: {
@@ -366,7 +369,7 @@ const Timeseries: FunctionComponent<TimeseriesProps> = ({
             },
             drawTicks: false,
             drawBorder: false,
-            color: theme === "light" ? AKSARA_COLOR.OUTLINE : AKSARA_COLOR.WASHED_DARK,
+            color: isLightMode ? AKSARA_COLOR.OUTLINE : AKSARA_COLOR.WASHED_DARK,
             offset: false,
             lineWidth(ctx) {
               if (ctx.tick.value === 0) return 2;

--- a/packages/datagovmy-ui/src/components/Modal/index.tsx
+++ b/packages/datagovmy-ui/src/components/Modal/index.tsx
@@ -76,7 +76,7 @@ const Modal: ForwardRefExoticComponent<ModalProps> = forwardRef(
                     </Dialog.Title>
                     <Button
                       variant="ghost"
-                      className="hover:bg-washed dark:hover:bg-washed-dark group absolute right-3 rounded-full p-0"
+                      className="hover:bg-washed dark:hover:bg-washed-dark group absolute right-1 rounded-full p-2"
                       onClick={() => setShow(false)}
                     >
                       <XMarkIcon className="text-dim mx-auto h-5 w-5 group-hover:text-black group-hover:dark:text-white" />


### PR DESCRIPTION
### Changes
1. DC Embed: fixed the colours in dark mode for Timeseries/Stacked Area chart, added `forcedTheme` to DC partials and charts to check using it instead of theme since the Embed Page is forced to use light mode: `CatalogueEmbed.theme = "light";` 
2. DC: Another issue, as the Timeseries/Stacked Area chart uses a hard-coded background colour (to maintain the translucent effect while preventing the colours from overlapping), in dark mode the png/svg download option will save the version with the dark colours on a transparent background which looks off. Not sure what's the fix for this. 
The root cause might be the translucent colours. But a Stacked Area chart without shade might be weird if we remove the shading. For now I made the bg color change when toggling theme so the issue isn't as obvious but this doesnt resolve the issue.
3. DC Index: Reduce padding between categories in mobile
4. KTM/Rapid Explorer: remove Dropdown min width requirement
5. Rapid: translate `A0: All stations`
6. Add Active Link to 404 page to get full redirect path for legacy site
7. Added Embed API to OpenDOSM for situations where filter options may change (eg. an Intraday chart), right now there is none but its here just in case, maybe can remove in future if not used
8. Income Tax: Fix hard-coded year, refactor loading state from using timeout