### PR TITLE
Opendosm/fix/upcoming calendar

### DIFF
--- a/apps/app/dashboards/economy/income-taxation/rank-me.tsx
+++ b/apps/app/dashboards/economy/income-taxation/rank-me.tsx
@@ -133,7 +133,9 @@ const IncomeRank: FunctionComponent<IncomeRankProps> = ({ year }) => {
       setData("percent", result.percentile);
       fetchData(value);
       if (size.width <= BREAKPOINTS.SM)
-        barRef && barRef.current && barRef.current.scrollIntoView({ behavior: "smooth" });
+        barRef &&
+          barRef.current &&
+          barRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
     } else setData("valid_amount", t("valid_amount"));
   };
 
@@ -203,9 +205,7 @@ const IncomeRank: FunctionComponent<IncomeRankProps> = ({ year }) => {
           <button className="btn-primary my-6" onClick={() => handleSearch(data.amount)}>
             {t("rank_me")}
           </button>
-          <p ref={barRef} className="text-dim text-sm">
-            {t("disclaimer", { year: year })}
-          </p>
+          <p className="text-dim text-sm">{t("disclaimer", { year: year })}</p>
         </Card>
         <div className="w-full sm:w-7/12 lg:w-2/3">
           {data.loading ? (
@@ -228,6 +228,7 @@ const IncomeRank: FunctionComponent<IncomeRankProps> = ({ year }) => {
                     <></>
                   ) : (
                     <div
+                      ref={barRef}
                       className="from-primary absolute bottom-0 w-full animate-[grow_1.5s_ease-in-out] rounded-md bg-gradient-to-t to-[#5B8EFF]"
                       style={{
                         ["--from-height" as string]: 0,

--- a/apps/app/dashboards/economy/income-taxation/rank-me.tsx
+++ b/apps/app/dashboards/economy/income-taxation/rank-me.tsx
@@ -19,7 +19,7 @@ import { FunctionComponent, useContext, useRef } from "react";
 
 /**
  * Income Taxation - Rank
- * @overview Status: In-development
+ * @overview Status: Live
  */
 
 type Percentile = {
@@ -119,10 +119,10 @@ const IncomeRank: FunctionComponent<IncomeRankProps> = ({ year }) => {
   };
 
   const handleChange = (e: string) => {
-    const value = e.replaceAll(/\D/g, "");
+    const value = e.replaceAll(/\D/g, ""); // replace all non-numbers
     const number = value ? Number(value) : null;
     if (typeof number === "number" && number >= 0) {
-      setData("amount", number.toLocaleString(i18n.language));
+      setData("amount", number.toLocaleString(i18n.language)); // comma-sep
     } else setData("amount", "");
     setData("valid_amount", false);
   };
@@ -235,19 +235,13 @@ const IncomeRank: FunctionComponent<IncomeRankProps> = ({ year }) => {
                         height: `${(result.percentile / 100) * 93 + 5}%`,
                       }}
                     >
-                      <div className="flex -translate-y-10 items-center lg:-translate-y-9">
-                        <div className="border-r-primary dark:border-r-primary-dark h-0 w-0 border-b-[7px] border-r-[7px] border-t-[7px] border-b-transparent border-t-transparent pl-5 lg:-translate-y-2"></div>
-                        <div className="flex w-max flex-col pb-3 pl-3">
+                      <>
+                        <div className="border-r-primary dark:border-r-primary-dark h-0 w-0 -translate-y-1.5 border-b-[7px] border-r-[7px] border-t-[7px] border-b-transparent border-t-transparent pl-5"></div>
+                        <div className="flex w-max -translate-y-9 flex-col pl-10">
                           <p className="whitespace-nowrap font-bold">{t("you_are_here")}</p>
-                          <p className="text-dim flex min-w-[120px] flex-wrap text-sm leading-tight">{`RM ${
-                            result.amount
-                          } ${
-                            result.variable === "income"
-                              ? t("annual_income").split(" (")[0]
-                              : t("annual_tax_paid")
-                          }`}</p>
+                          <p className="text-dim flex max-w-[120px] flex-wrap text-sm">{`RM ${result.amount}`}</p>
                         </div>
-                      </div>
+                      </>
                     </div>
                   )}
                   <div className="text-dim flex -translate-x-14 flex-col gap-[25px] whitespace-nowrap text-right text-sm lg:gap-[37px]">

--- a/apps/opendosm/misc/publications/upcoming.tsx
+++ b/apps/opendosm/misc/publications/upcoming.tsx
@@ -22,7 +22,7 @@ import { FunctionComponent, useContext, useEffect, useMemo, useRef } from "react
 
 /**
  * Upcoming Publications
- * @overview Status: In-development
+ * @overview Status: Live
  */
 
 const Table = dynamic(() => import("datagovmy-ui/charts/table"), {
@@ -75,10 +75,12 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
   }));
 
   const today = new Date();
-  const todayISO = today.toISOString().split("T")[0];
-
   const thisMonth = today.getMonth(); // 0 - 11
   const thisYear = today.getFullYear();
+
+  const todayISO = new Date(thisYear, thisMonth, today.getDate(), 8, 0, 0)
+    .toISOString()
+    .split("T")[0];
   const daysInWeek: string[] = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
 
   const getMonthAndYear = (isoDate: string): [month: number, year: number] => {

--- a/apps/opendosm/misc/publications/upcoming.tsx
+++ b/apps/opendosm/misc/publications/upcoming.tsx
@@ -129,17 +129,17 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
     setFilter("start", toDate(new Date(data.year, data.month, -firstDay + 1, 8, 0, 0)));
     setFilter("end", toDate(new Date(data.year, data.month + 1, remaining, 8, 0, 0)));
 
+    // for desktop only, prev month
     for (let i = firstDay - 1; i >= 0; i--) {
-      // for desktop only, prev month
       const date = toDate(new Date(data.year, data.month - 1, daysInLastMonth - i, 8, 0, 0));
       desktop.push({
         date: date, // to match for publications
-        day: daysInLastMonth - i, // to match for current month
-        month: data.month - 1, // to display day in calendar
+        day: daysInLastMonth - i, // to display day in calendar
+        month: data.month - 1, // to match for current month
       });
     }
+    // for curr month
     for (let i = 1; i <= daysInCurrMonth; i++) {
-      // for curr month
       const date = toDate(new Date(data.year, data.month, i, 8, 0, 0));
       const pub: ScheduledPub = {
         date: date,
@@ -149,8 +149,8 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
       desktop.push(pub);
       mobile.push(pub);
     }
+    // for desktop only, next month
     for (let i = 1; i < 7; i++) {
-      // for desktop only, next month
       if (desktop.length % 7 === 0) break;
       const date = toDate(new Date(data.year, data.month + 1, i, 8, 0, 0));
       desktop.push({

--- a/apps/opendosm/misc/publications/upcoming.tsx
+++ b/apps/opendosm/misc/publications/upcoming.tsx
@@ -16,6 +16,7 @@ import { clx, toDate } from "datagovmy-ui/helpers";
 import { useData, useFilter, useTranslation } from "datagovmy-ui/hooks";
 import { OptionType } from "datagovmy-ui/types";
 import chunk from "lodash/chunk";
+import { DateTime } from "luxon";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { FunctionComponent, useContext, useEffect, useMemo, useRef } from "react";
@@ -130,7 +131,7 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
     setFilter("end", toDate(new Date(data.year, data.month + 1, remaining, 8, 0, 0)));
 
     // for desktop only, prev month
-    for (let i = firstDay - 1; i >= 0; i--) {
+    for (let i = firstDay; i > 0; i--) {
       const date = toDate(new Date(data.year, data.month - 1, daysInLastMonth - i, 8, 0, 0));
       desktop.push({
         date: date, // to match for publications
@@ -329,7 +330,7 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
                       {calendar.desktop.map((week, i) => (
                         <tr key={i} className="divide-x divide-outline dark:divide-washed-dark">
                           {week.map(d => {
-                            const isToday = todayISO === d.date;
+                            const isToday = DateTime.fromISO(d.date).hasSame(DateTime.now(), "day");
                             const notThisMonth = d.month !== data.month;
 
                             return (
@@ -388,7 +389,7 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
                 </div>
                 <div className="grid grid-cols-1 gap-3 md:max-lg:grid-cols-2 lg:hidden">
                   {calendar.mobile.map(d => {
-                    const isToday = todayISO === d.date;
+                    const isToday = DateTime.fromISO(d.date).hasSame(DateTime.now(), "day");
 
                     if (!(d.date in cal_pubs)) return;
                     return (

--- a/apps/opendosm/misc/publications/upcoming.tsx
+++ b/apps/opendosm/misc/publications/upcoming.tsx
@@ -112,34 +112,34 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
       : undefined,
   });
 
-  const pubs = new Map<string, string[]>(Object.entries(cal_pubs));
-
   const calendar = useMemo(() => {
     let desktop: ScheduledPub[] = [];
     let mobile: ScheduledPub[] = [];
 
-    const daysInLastMonth = new Date(data.year, data.month, 0).getDate();
-    const firstDay = new Date(data.year, data.month).getDay();
-    const daysInCurrMonth = new Date(data.year, data.month + 1, 0).getDate();
-    const totalModuloSeven = (firstDay + daysInCurrMonth) % 7;
-    const remaining = totalModuloSeven === 0 ? 0 : 7 - totalModuloSeven;
+    const daysInLastMonth = new Date(data.year, data.month, 0).getDate(); // for desktop, to get total days in prev month
+    const firstDay = new Date(data.year, data.month).getDay(); // to get day of week, 0 - 6 = Sun - Sat
+    const daysInCurrMonth = new Date(data.year, data.month + 1, 0).getDate(); // to get total days in curr month
+    const totalModuloSeven = (firstDay + daysInCurrMonth) % 7; // to get number of days in last week of curr month
+    const remaining = totalModuloSeven === 0 ? 0 : 7 - totalModuloSeven; // for desktop, num of days in next month needed to fill remainder
 
     const toDate = (date: Date): string => {
-      return date.toISOString().split("T")[0];
+      return date.toISOString().split("T")[0]; // get date in yyyy-mm-dd
     };
 
     setFilter("start", toDate(new Date(data.year, data.month, -firstDay + 1, 8, 0, 0)));
     setFilter("end", toDate(new Date(data.year, data.month + 1, remaining, 8, 0, 0)));
 
     for (let i = firstDay - 1; i >= 0; i--) {
+      // for desktop only, prev month
       const date = toDate(new Date(data.year, data.month - 1, daysInLastMonth - i, 8, 0, 0));
       desktop.push({
-        date: date,
-        day: daysInLastMonth - i,
-        month: data.month - 1,
+        date: date, // to match for publications
+        day: daysInLastMonth - i, // to match for current month
+        month: data.month - 1, // to display day in calendar
       });
     }
     for (let i = 1; i <= daysInCurrMonth; i++) {
+      // for curr month
       const date = toDate(new Date(data.year, data.month, i, 8, 0, 0));
       const pub: ScheduledPub = {
         date: date,
@@ -150,6 +150,7 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
       mobile.push(pub);
     }
     for (let i = 1; i < 7; i++) {
+      // for desktop only, next month
       if (desktop.length % 7 === 0) break;
       const date = toDate(new Date(data.year, data.month + 1, i, 8, 0, 0));
       desktop.push({
@@ -159,7 +160,7 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
       });
     }
 
-    return { desktop: chunk(desktop, 7), mobile };
+    return { desktop: chunk(desktop, 7), mobile }; // chunk into arrays of size 7
   }, [data.month, i18n.language]);
 
   const config: TableConfig[] = [
@@ -203,7 +204,6 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
     const scrollOptions: ScrollIntoViewOptions = {
       behavior: "smooth",
       block: "center",
-      inline: "end",
     };
     if (size.width >= BREAKPOINTS.LG) desktopRef.current[todayISO]?.scrollIntoView(scrollOptions);
     else mobileRef.current[todayISO]?.scrollIntoView(scrollOptions);
@@ -331,7 +331,6 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
                           {week.map(d => {
                             const isToday = todayISO === d.date;
                             const notThisMonth = d.month !== data.month;
-                            const id = `${d.date}_${i18n.language}`;
 
                             return (
                               <td
@@ -367,8 +366,8 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
                                   </span>
 
                                   <div className="flex h-full flex-col justify-start gap-1.5">
-                                    {pubs.has(id) &&
-                                      pubs.get(id).map((pub, i) => (
+                                    {d.date in cal_pubs &&
+                                      cal_pubs[d.date].map((pub, i) => (
                                         <Tooltip key={`desktop_${pub}_${d.date}_${i}`} tip={pub}>
                                           {() => (
                                             <p className="h-6 w-full truncate rounded bg-primary/20 px-1.5 py-1 text-xs text-black dark:text-white">
@@ -390,8 +389,8 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
                 <div className="grid grid-cols-1 gap-3 md:max-lg:grid-cols-2 lg:hidden">
                   {calendar.mobile.map(d => {
                     const isToday = todayISO === d.date;
-                    const id = `${d.date}_${i18n.language}`;
-                    if (!pubs.has(id)) return;
+
+                    if (!(d.date in cal_pubs)) return;
                     return (
                       <div
                         key={d.date}
@@ -420,8 +419,8 @@ const UpcomingPublicationsDashboard: FunctionComponent<UpcomingPublicationsProps
                               {d.day}
                             </span>
                           </div>
-                          {pubs.has(id) &&
-                            pubs.get(id).map((pub, i) => (
+                          {d.date in cal_pubs &&
+                            cal_pubs[d.date].map((pub, i) => (
                               <Tooltip tip={pub} key={`mobile_${pub}_${d.date}_${i}`}>
                                 {open => (
                                   <div

--- a/apps/opendosm/pages/publications/upcoming/index.tsx
+++ b/apps/opendosm/pages/publications/upcoming/index.tsx
@@ -79,12 +79,11 @@ export const getServerSideProps: GetServerSideProps = withi18n(
         throw new Error("Invalid filter. Message: " + e);
       });
 
-      // rename keys and map array values
+      // map to array of only publication titles
       const transform = (input: Record<string, UpcomingPublication[]>) => {
         const result: Record<string, string[]> = {};
-        for (const oldKey in input) {
-          const newKey = `${oldKey}_${locale}`;
-          result[newKey] = input[oldKey].map(e => e.publication_title);
+        for (const key in input) {
+          result[key] = input[key].map(e => e.publication_title);
         }
         return result;
       };


### PR DESCRIPTION
### Changes
- Income Tax: simplify styling for amount part in barmeter chart, improve `scrollIntoView()` positioning on mobile
- Upcoming Publications
  -  bug: `todayISO` is used to store today's date in "yyyy-mm-dd" format, 1 of the way to get the date in that format is to use `toISOString()`, but that meant the date was in the UTC/GMT+0 timezone, fixed this by adding the difference (+8) manually 
  - remove using Map to store publications, remove using locale to label date keys (originally meant to use map+locale label to cache)
  - add comments
