### PR TITLE
fix: bar chart datalabel for undefined

### DIFF
--- a/packages/datagovmy-ui/src/charts/bar.tsx
+++ b/packages/datagovmy-ui/src/charts/bar.tsx
@@ -162,7 +162,7 @@ const Bar: FunctionComponent<BarProps> = ({
       },
       crosshair: false,
       annotation: false,
-      datalabels: datalabels,
+      datalabels: datalabels || false,
     },
     scales: {
       x: {


### PR DESCRIPTION
`datalabels` property in `<Bar />` chart component is still rendering datalabels despite receiving undefined.

Added falsy behavior which sets datalabels property in Bar chart `options` prop to ensure datalabel is not rendered