### PR TITLE
feat: add dropdown for link editions download in data catalogue (#514)

### DIFF
--- a/packages/datagovmy-ui/src/data-catalogue/Show/index.tsx
+++ b/packages/datagovmy-ui/src/data-catalogue/Show/index.tsx
@@ -253,6 +253,7 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
                 data_source: data.data_source,
                 link_csv: data.link_csv,
                 link_parquet: data.link_parquet,
+                link_editions: data.link_editions,
               }}
             />
             {/* Download */}

--- a/packages/datagovmy-ui/types/data-catalogue.d.ts
+++ b/packages/datagovmy-ui/types/data-catalogue.d.ts
@@ -72,6 +72,7 @@ export type DCVariable = {
   link_parquet: string;
   link_csv: string;
   link_preview: string;
+  link_editions?: string[];
   frequency: keyof typeof SHORT_PERIOD;
   data_source: Array<string>;
   fields: Array<DCField>;


### PR DESCRIPTION
* feat: add dropdown for link editions download in data catalogue

* refactor: implement hasEditions, getUrl and remove redundant useEffect