### PR TITLE
Fix/catalogue

### DIFF
--- a/packages/datagovmy-ui/src/charts/bar.tsx
+++ b/packages/datagovmy-ui/src/charts/bar.tsx
@@ -156,7 +156,8 @@ const Bar: FunctionComponent<BarProps> = ({
             return `${item.dataset.label}: ${tip[layout]}`;
           },
           title(item) {
-            return formatX ? formatX(item[0].label) : item[0].label;
+            const label = item[0].label.trim();
+            return formatX ? formatX(label) : label;
           },
         },
       },

--- a/packages/datagovmy-ui/src/contexts/catalogue.tsx
+++ b/packages/datagovmy-ui/src/contexts/catalogue.tsx
@@ -79,24 +79,41 @@ export const CatalogueProvider: ForwardRefExoticComponent<CatalogueProviderProps
 
     const _dataset = useMemo(() => {
       if (["TIMESERIES", "STACKED_AREA", "INTRADAY"].includes(dataset.type)) {
-        const numOfValidItems: Array<number> = [];
-        const chart = Object.entries(dataset.chart)
-          .filter(([key, _]) => key !== "x")
-          .map(([key, y]) => [key, (y as number[]).filter(item => item !== null)]);
+        const { x, ...y } = dataset.chart as Record<string, number[]> & { x: string[] };
 
-        chart.forEach(([key, y]) => {
-          numOfValidItems.push((y as number[]).length);
-        });
+        let x_vals = x;
+        // trim null values off start and end
+        const trimmed_y = Object.fromEntries(
+          Object.entries(y).map(([key, y_values], _, ori_arr) => {
+            let y_vals: number[] = y_values;
 
-        const finalChart = {
-          x: dataset.chart.x.slice(
-            dataset.chart.x.length - numOfValidItems.sort((a, b) => b - a)[0]
-          ),
-          ...Object.fromEntries(chart),
-        };
+            // loop from start
+            for (let i = 0; i < y_values.length; i++) {
+              // if any y-value is not null, break loop and keep the values
+              if (ori_arr.some(([_, y_vals]) => y_vals[i] !== null)) break;
+              // else if all y-values are null, slice first value from array
+              else {
+                x_vals = x_vals.slice(i + 1);
+                y_vals = y_vals.slice(i + 1);
+              }
+            }
 
-        return { ...dataset, chart: finalChart };
-        // return { ...dataset}
+            // loop from end
+            for (let i = y_vals.length - 1; i >= 0; i--) {
+              // if any y-value is not null, break loop and keep the values
+              if (ori_arr.some(([_, y_vals]) => y_vals[i] !== null)) break;
+              // else if all y-values are null, slice last value from array
+              else {
+                x_vals = x_vals.slice(0, i);
+                y_vals = y_vals.slice(0, i);
+              }
+            }
+
+            return [key, y_vals];
+          })
+        );
+
+        return { ...dataset, chart: { x: x_vals, ...trimmed_y } };
       }
       return dataset;
     }, [dataset]);

--- a/packages/datagovmy-ui/src/lib/helpers.ts
+++ b/packages/datagovmy-ui/src/lib/helpers.ts
@@ -340,7 +340,7 @@ export const exportAs = async (
  * @returns {string | ReactElement[]} string | React elements
  */
 export const interpolate = (raw_text: string): string | ReactElement[] => {
-  const delimiter = /\[(.+?)\]\((.+?)\)/;
+  const delimiter = /\[(.*?)\)/;
   let matches = raw_text.split(delimiter);
 
   if (matches.length <= 1) return raw_text;

--- a/packages/datagovmy-ui/src/misc/odin/OdinSummary.tsx
+++ b/packages/datagovmy-ui/src/misc/odin/OdinSummary.tsx
@@ -147,7 +147,6 @@ const OdinSummary: FunctionComponent<OdinSummaryProps> = ({ bar, scores, title, 
                   enableGridY={false}
                   enableGridX={true}
                   maxX={scores.maximum[i + 1]}
-                  formatX={string => string.trim()}
                   precision={0}
                   data={{
                     labels: scores.subelement.slice(1).map((e: string) => t(e)),

--- a/packages/datagovmy-ui/src/misc/odin/OdinSummary.tsx
+++ b/packages/datagovmy-ui/src/misc/odin/OdinSummary.tsx
@@ -147,6 +147,7 @@ const OdinSummary: FunctionComponent<OdinSummaryProps> = ({ bar, scores, title, 
                   enableGridY={false}
                   enableGridX={true}
                   maxX={scores.maximum[i + 1]}
+                  formatX={string => string.trim()}
                   precision={0}
                   data={{
                     labels: scores.subelement.slice(1).map((e: string) => t(e)),


### PR DESCRIPTION
### Changes
- Trim null values from start and end of Catalogue Timeseries/Stacked/Intraday charts
- Trim Bar Chart tooltip whitespace by default
- Revert `interpolate()` helper regex