### PR TITLE
feat(dc-gui): save output in case of error

### DIFF
--- a/apps/app/lib/data-catalogue.ts
+++ b/apps/app/lib/data-catalogue.ts
@@ -57,7 +57,7 @@ async function openDataCataloguePR(
     sha: baseSha,
   });
 
-  const commitMessage = `Automated: Create/update data catalogue '${fileName}'`;
+  const commitMessage = `Automated: Create data catalogue '${fileName}'`;
   await octokit.rest.repos.createOrUpdateFileContents({
     ...REPO_INFO,
     path: `data-catalogue/${fileName}`,

--- a/apps/app/misc/gui/landing.tsx
+++ b/apps/app/misc/gui/landing.tsx
@@ -166,7 +166,7 @@ const GUIDCLanding: FunctionComponent<GUIDCLandingProps> = ({}) => {
             onPublish={json => {
               publishDataCatalogue({
                 fileName: `${data["file_name"]}.json`,
-                data: window.btoa(json),
+                json,
               });
             }}
             resetData={reset}

--- a/apps/app/misc/gui/step-basic.tsx
+++ b/apps/app/misc/gui/step-basic.tsx
@@ -324,8 +324,8 @@ const StepBasic: FunctionComponent<StepBasicProps> = ({
               {validation.link_csv === "loading"
                 ? t("forms.fetching")
                 : validation.link_csv === "success"
-                ? t("forms.success")
-                : t("forms.test_link")}
+                  ? t("forms.success")
+                  : t("forms.test_link")}
             </Button>
           </div>
           <div className="flex">
@@ -377,8 +377,8 @@ const StepBasic: FunctionComponent<StepBasicProps> = ({
               {validation.link_parquet === "loading"
                 ? t("forms.fetching")
                 : validation.link_parquet === "success"
-                ? t("forms.success")
-                : t("forms.test_link")}
+                  ? t("forms.success")
+                  : t("forms.test_link")}
             </Button>
           </div>
           <div className="flex">
@@ -429,8 +429,8 @@ const StepBasic: FunctionComponent<StepBasicProps> = ({
               {validation.link_preview === "loading"
                 ? t("forms.fetching")
                 : validation.link_preview === "success"
-                ? t("forms.success")
-                : t("forms.test_link")}
+                  ? t("forms.success")
+                  : t("forms.test_link")}
             </Button>
           </div>
         </div>
@@ -625,7 +625,6 @@ const StepBasic: FunctionComponent<StepBasicProps> = ({
               <Label label={t("forms.data_as_of")} name={t("forms.data_as_of")} required={true} />
               <Input
                 required
-                autoFocus
                 type={"datetime-local"}
                 className="w-full rounded-lg py-1.5"
                 name="data_as_of"


### PR DESCRIPTION
In case the call to `POST /api/data-catalogue/open-pr` fails, let the user save the json file

https://github.com/user-attachments/assets/c4412a3c-3415-4e09-b164-a8d0a01c9d4b

