### PR TITLE
fix: dc timeseries slider date sorting

### DIFF
--- a/packages/datagovmy-ui/src/charts/partials/timeseries.tsx
+++ b/packages/datagovmy-ui/src/charts/partials/timeseries.tsx
@@ -109,7 +109,9 @@ const CatalogueTimeseries: FunctionComponent<CatalogueTimeseriesProps> = ({
               <Slider
                 className="pt-4"
                 type="range"
-                data={dataset.chart.x}
+                data={dataset.chart.x.sort(
+                  (a: string, b: string) => new Date(a).getTime() - new Date(b).getTime()
+                )}
                 value={data.minmax}
                 period={SHORT_PERIOD[config.range]}
                 onChange={e => setData("minmax", e)}


### PR DESCRIPTION
DC timeseries slider uses data value without sorting. As a result, when data start with latest to oldest, the slider also reflects the same.

This PR sorts the DC timeseries slider and ensures slider shown correctly.