### PR TITLE
[Feature] Add scrollspy to the data catalogue sidebar

### DIFF
--- a/packages/datagovmy-ui/src/components/Sidebar/index.tsx
+++ b/packages/datagovmy-ui/src/components/Sidebar/index.tsx
@@ -24,7 +24,6 @@ interface SidebarProps {
   mobileClassName?: string;
   initialSelected?: string;
   sectionRefs?: RefObject<Record<string, HTMLElement | null>>;
-  scrollOffset?: number;
   customList?: (
     setSelected: (value: SetStateAction<string>) => void,
     onSelect: (index: string) => void,
@@ -41,7 +40,6 @@ const Sidebar: FunctionComponent<SidebarProps> = ({
   mobileClassName,
   initialSelected,
   sectionRefs,
-  scrollOffset = 180,
   customList,
 }) => {
   const { t } = useTranslation(["catalogue", "common"]);
@@ -57,7 +55,7 @@ const Sidebar: FunctionComponent<SidebarProps> = ({
     setSelected(id);
   }, []);
 
-  useActiveSection(sectionRefs, scrollOffset, onActiveSection);
+  useActiveSection(sectionRefs, 180, onActiveSection);
   const styles = {
     base: "px-4 lg:px-5 py-1.5 w-full rounded-none text-start leading-tight",
     active:

--- a/packages/datagovmy-ui/src/components/Sidebar/index.tsx
+++ b/packages/datagovmy-ui/src/components/Sidebar/index.tsx
@@ -1,9 +1,20 @@
-import { FunctionComponent, ReactNode, SetStateAction, useState } from "react";
+import {
+  FunctionComponent,
+  ReactNode,
+  RefObject,
+  SetStateAction,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 import { Transition } from "@headlessui/react";
 import Button from "../Button";
 import { Bars3BottomLeftIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { useTranslation } from "../../hooks/useTranslation";
+import { useActiveSection } from "../../hooks/useActiveSection";
 import { clx } from "../../lib/helpers";
+
+const SUPPRESS_MS = 800;
 
 interface SidebarProps {
   children: ReactNode;
@@ -12,6 +23,8 @@ interface SidebarProps {
   sidebarTitle?: string;
   mobileClassName?: string;
   initialSelected?: string;
+  sectionRefs?: RefObject<Record<string, HTMLElement | null>>;
+  scrollOffset?: number;
   customList?: (
     setSelected: (value: SetStateAction<string>) => void,
     onSelect: (index: string) => void,
@@ -27,6 +40,8 @@ const Sidebar: FunctionComponent<SidebarProps> = ({
   sidebarTitle,
   mobileClassName,
   initialSelected,
+  sectionRefs,
+  scrollOffset = 180,
   customList,
 }) => {
   const { t } = useTranslation(["catalogue", "common"]);
@@ -34,6 +49,15 @@ const Sidebar: FunctionComponent<SidebarProps> = ({
     initialSelected ?? Array.isArray(categories[0]) ? categories[0][0] : categories[0]
   );
   const [show, setShow] = useState<boolean>(false);
+
+  const clickedAt = useRef(0);
+
+  const onActiveSection = useCallback((id: string) => {
+    if (Date.now() - clickedAt.current < SUPPRESS_MS) return;
+    setSelected(id);
+  }, []);
+
+  useActiveSection(sectionRefs, scrollOffset, onActiveSection);
   const styles = {
     base: "px-4 lg:px-5 py-1.5 w-full rounded-none text-start leading-tight",
     active:
@@ -62,6 +86,7 @@ const Sidebar: FunctionComponent<SidebarProps> = ({
                         selected === `${category}` ? styles.active : styles.default,
                       ].join(" ")}
                       onClick={() => {
+                        clickedAt.current = Date.now();
                         setSelected(`${category}`);
                         onSelect(
                           subcategory.length > 0 ? `${category}: ${subcategory[0]}` : `${category}`
@@ -82,6 +107,7 @@ const Sidebar: FunctionComponent<SidebarProps> = ({
                                   : styles.default,
                               ].join(" ")}
                               onClick={() => {
+                                clickedAt.current = Date.now();
                                 setSelected(`${category}: ${title}`);
                                 onSelect(`${category}: ${title}`);
                               }}
@@ -154,6 +180,7 @@ const Sidebar: FunctionComponent<SidebarProps> = ({
                             selected === category ? styles.active : styles.default,
                           ].join(" ")}
                           onClick={() => {
+                            clickedAt.current = Date.now();
                             setSelected(category);
                             onSelect(
                               subcategory.length > 0
@@ -174,6 +201,7 @@ const Sidebar: FunctionComponent<SidebarProps> = ({
                                     selected === title ? styles.active : styles.default,
                                   ].join(" ")}
                                   onClick={() => {
+                                    clickedAt.current = Date.now();
                                     setSelected(title);
                                     onSelect(`${category}: ${title}`);
                                   }}

--- a/packages/datagovmy-ui/src/components/Sidebar/index.tsx
+++ b/packages/datagovmy-ui/src/components/Sidebar/index.tsx
@@ -14,8 +14,6 @@ import { useTranslation } from "../../hooks/useTranslation";
 import { useActiveSection } from "../../hooks/useActiveSection";
 import { clx } from "../../lib/helpers";
 
-const SUPPRESS_MS = 800;
-
 interface SidebarProps {
   children: ReactNode;
   categories: Array<[category: string, subcategory: string[]]>;
@@ -48,10 +46,15 @@ const Sidebar: FunctionComponent<SidebarProps> = ({
   );
   const [show, setShow] = useState<boolean>(false);
 
-  const clickedAt = useRef(0);
+  // Mute the scrollspy until a click-triggered scroll settles.
+  const suppressed = useRef(false);
+  const suppressUntilScrollEnd = useCallback(() => {
+    suppressed.current = true;
+    window.addEventListener("scrollend", () => (suppressed.current = false), { once: true });
+  }, []);
 
   const onActiveSection = useCallback((id: string) => {
-    if (Date.now() - clickedAt.current < SUPPRESS_MS) return;
+    if (suppressed.current) return;
     setSelected(id);
   }, []);
 
@@ -84,7 +87,7 @@ const Sidebar: FunctionComponent<SidebarProps> = ({
                         selected === `${category}` ? styles.active : styles.default,
                       ].join(" ")}
                       onClick={() => {
-                        clickedAt.current = Date.now();
+                        suppressUntilScrollEnd();
                         setSelected(`${category}`);
                         onSelect(
                           subcategory.length > 0 ? `${category}: ${subcategory[0]}` : `${category}`
@@ -105,7 +108,7 @@ const Sidebar: FunctionComponent<SidebarProps> = ({
                                   : styles.default,
                               ].join(" ")}
                               onClick={() => {
-                                clickedAt.current = Date.now();
+                                suppressUntilScrollEnd();
                                 setSelected(`${category}: ${title}`);
                                 onSelect(`${category}: ${title}`);
                               }}
@@ -178,7 +181,7 @@ const Sidebar: FunctionComponent<SidebarProps> = ({
                             selected === category ? styles.active : styles.default,
                           ].join(" ")}
                           onClick={() => {
-                            clickedAt.current = Date.now();
+                            suppressUntilScrollEnd();
                             setSelected(category);
                             onSelect(
                               subcategory.length > 0
@@ -199,7 +202,7 @@ const Sidebar: FunctionComponent<SidebarProps> = ({
                                     selected === title ? styles.active : styles.default,
                                   ].join(" ")}
                                   onClick={() => {
-                                    clickedAt.current = Date.now();
+                                    suppressUntilScrollEnd();
                                     setSelected(title);
                                     onSelect(`${category}: ${title}`);
                                   }}

--- a/packages/datagovmy-ui/src/data-catalogue/Main/index.tsx
+++ b/packages/datagovmy-ui/src/data-catalogue/Main/index.tsx
@@ -151,6 +151,7 @@ const CatalogueIndex: FunctionComponent<CatalogueIndexProps> = ({
 
       <Container className="min-h-screen lg:px-0 lg:pl-6">
         <Sidebar
+          sectionRefs={scrollRef}
           categories={Object.entries(collection).map(([category, subcategory]) => [
             category,
             Object.keys(subcategory),

--- a/packages/datagovmy-ui/src/data-catalogue/Show/index.tsx
+++ b/packages/datagovmy-ui/src/data-catalogue/Show/index.tsx
@@ -212,6 +212,7 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
     <div>
       <Container className="min-h-screen">
         <Sidebar
+          sectionRefs={scrollRef}
           categories={Object.entries(
             getSideBarCollection({
               publications: Boolean(data.publication),

--- a/packages/datagovmy-ui/src/hooks/index.ts
+++ b/packages/datagovmy-ui/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useActiveSection } from "./useActiveSection";
 export { useAnalytics } from "./useAnalytics";
 export { useCache } from "./useCache";
 export { useColor } from "./useColor";

--- a/packages/datagovmy-ui/src/hooks/useActiveSection.ts
+++ b/packages/datagovmy-ui/src/hooks/useActiveSection.ts
@@ -1,5 +1,6 @@
 import { RefObject, useEffect } from "react";
 
+// Highlights the section crossing a 1px line `offset`px below the viewport top.
 export const useActiveSection = (
   sectionRefs: RefObject<Record<string, HTMLElement | null>> | undefined,
   offset: number,
@@ -7,47 +8,31 @@ export const useActiveSection = (
 ) => {
   useEffect(() => {
     if (!sectionRefs?.current) return;
+    const sections = Object.entries(sectionRefs.current).filter(([, el]) => el) as Array<
+      [string, HTMLElement]
+    >;
+    if (sections.length === 0) return;
 
-    const idByElement = new Map<Element, string>();
-    Object.entries(sectionRefs.current).forEach(([id, el]) => el && idByElement.set(el, id));
-    if (idByElement.size === 0) return;
+    const idByElement = new Map<Element, string>(sections.map(([id, el]) => [el, id]));
 
-    const pick = () => {
-      let crossed: Element | undefined; // last section whose top has passed the line
-      let crossedTop = -Infinity;
-      let topmost: Element | undefined; // first section, when none has crossed yet
-      let topmostTop = Infinity;
-      idByElement.forEach((_, el) => {
-        const top = el.getBoundingClientRect().top;
-        if (top <= offset + 1 && top > crossedTop) {
-          crossedTop = top;
-          crossed = el;
-        }
-        if (top < topmostTop) {
-          topmostTop = top;
-          topmost = el;
-        }
-      });
-      const active = crossed ?? topmost;
-      if (active) onActive(idByElement.get(active)!);
+    let observer: IntersectionObserver;
+    const setup = () => {
+      observer?.disconnect();
+      observer = new IntersectionObserver(
+        entries => {
+          const hit = entries.find(e => e.isIntersecting);
+          if (hit) onActive(idByElement.get(hit.target)!);
+        },
+        { rootMargin: `-${offset}px 0px -${window.innerHeight - offset - 1}px 0px` }
+      );
+      idByElement.forEach((_, el) => observer.observe(el));
     };
 
-    let ticking = false;
-    const onScroll = () => {
-      if (ticking) return;
-      ticking = true;
-      requestAnimationFrame(() => {
-        pick();
-        ticking = false;
-      });
-    };
-
-    pick();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    window.addEventListener("resize", onScroll, { passive: true });
+    setup();
+    window.addEventListener("resize", setup); // rootMargin is in px, recompute on resize
     return () => {
-      window.removeEventListener("scroll", onScroll);
-      window.removeEventListener("resize", onScroll);
+      observer.disconnect();
+      window.removeEventListener("resize", setup);
     };
   }, [sectionRefs, offset, onActive]);
 };

--- a/packages/datagovmy-ui/src/hooks/useActiveSection.ts
+++ b/packages/datagovmy-ui/src/hooks/useActiveSection.ts
@@ -1,0 +1,53 @@
+import { RefObject, useEffect } from "react";
+
+export const useActiveSection = (
+  sectionRefs: RefObject<Record<string, HTMLElement | null>> | undefined,
+  offset: number,
+  onActive: (id: string) => void
+) => {
+  useEffect(() => {
+    if (!sectionRefs?.current) return;
+
+    const idByElement = new Map<Element, string>();
+    Object.entries(sectionRefs.current).forEach(([id, el]) => el && idByElement.set(el, id));
+    if (idByElement.size === 0) return;
+
+    const pick = () => {
+      let crossed: Element | undefined; // last section whose top has passed the line
+      let crossedTop = -Infinity;
+      let topmost: Element | undefined; // first section, when none has crossed yet
+      let topmostTop = Infinity;
+      idByElement.forEach((_, el) => {
+        const top = el.getBoundingClientRect().top;
+        if (top <= offset + 1 && top > crossedTop) {
+          crossedTop = top;
+          crossed = el;
+        }
+        if (top < topmostTop) {
+          topmostTop = top;
+          topmost = el;
+        }
+      });
+      const active = crossed ?? topmost;
+      if (active) onActive(idByElement.get(active)!);
+    };
+
+    let ticking = false;
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        pick();
+        ticking = false;
+      });
+    };
+
+    pick();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+    };
+  }, [sectionRefs, offset, onActive]);
+};


### PR DESCRIPTION
## What
As user scroll a data catalogue page, the sidebar now automatically highlights the section you're currently viewing. Clicking a sidebar link still scrolls to that section as before.

Resolves issue #649 

## How

- Implement a new`useActiveSection` hook that watches the page sections and identify which one is under a line that we defined (currently ~180px) below the top of the viewport. Uses the browser's native `IntersectionObserver`.
- At the same time, the sidebar mutes the scrollspy while a click-triggered scroll is in flight (with the `scrollend` event implementation), so this means the click isn't overwritten mid-scroll.

Fairly new to React. Would appreciate some comments/guidance



https://github.com/user-attachments/assets/3f85bb31-5bdc-4561-8a11-c913b79bd864





